### PR TITLE
Various cleanups

### DIFF
--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -117,7 +117,7 @@ class Sandbox {
      * @return @p true if successful, @p false otherwise. @p errno will be set
      * upon failure.
      */
-    bool copyString (Address addr, int maxLength, char* buf);
+    bool copyString (Address addr, size_t maxLength, char* buf);
 
     /**
      * Write a single word to the child process' memory

--- a/src/sandbox-node-module.cpp
+++ b/src/sandbox-node-module.cpp
@@ -200,7 +200,7 @@ class NodeSandbox : public Sandbox {
     }
 
     void handleSignal(int signal) override {
-      if (m_debuggerOnCrash && signal == SIGSEGV) {
+      if (m_debuggerOnCrash && (signal == SIGSEGV || signal == SIGABRT)) {
         launchDebugger();
       }
       std::vector<Handle<Value> > args = {

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -373,10 +373,7 @@ Sandbox::writeData (Address addr, size_t length, const char* buf)
     for (size_t j = 0; j < sizeof (Word) && i+j < length; j++) {
       ((char*)(&d))[j] = buf[i+j];
     }
-    do {
-      errno = 0;
-      pokeData (addr + i, d);
-    } while (errno == ERESTART);
+    pokeData (addr + i, d);
   }
   if (i != length) {
     Word d = peekData (addr + i);

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -446,9 +446,22 @@ handle_trap(uv_signal_t *handle, int signum)
         priv->handleSeccompEvent();
         ptrace (PTRACE_CONT, priv->pid, 0, 0);
       } else if (s == PTRACE_EVENT_EXIT) {
-        ptrace (PTRACE_GETEVENTMSG, priv->pid, 0, &status);
-        priv->d->handleExit (WEXITSTATUS (status));
-        priv->d->releaseChild(0);
+          ptrace (PTRACE_GETEVENTMSG, priv->pid, 0, &status);
+          if (WIFSIGNALED (status) && WTERMSIG (status) == SIGSYS) {
+            struct user_regs_struct regs;
+            ptrace (PTRACE_GETREGS, priv->pid, 0, &regs);
+            std::cout << "died on bad syscall " << regs.orig_rax << std::endl;
+            ptrace (PTRACE_CONT, priv->pid, 0, 0);
+          } else {
+            if (WIFSIGNALED (status)) {
+              priv->d->handleSignal (WTERMSIG (status));
+              priv->d->handleExit (WTERMSIG (status));
+            } else {
+              assert (WIFEXITED (status));
+              priv->d->handleExit (WEXITSTATUS (status));
+            }
+            priv->d->releaseChild(0);
+          }
       } else if (s == PTRACE_EVENT_EXEC) {
         priv->handleExecEvent();
         ptrace (PTRACE_CONT, priv->pid, 0, 0);

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -202,6 +202,7 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mmap), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (brk), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (munmap), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (madvise), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (gettid), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (clock_getres), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (rt_sigprocmask), 0);
@@ -211,6 +212,9 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (pipe2), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_create1), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (futex), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (clock_nanosleep), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (nanosleep), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (exit_group), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_wait), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_ctl), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (getcwd), 0);

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -494,10 +494,10 @@ Sandbox::traceChild()
   SandboxWrap* wrap = new SandboxWrap;
   wrap->priv = priv;
   priv->signal.data = wrap;
-  uv_signal_start (&priv->signal, handle_trap, SIGCHLD);
 
   for (auto i = priv->ipcSockets.begin(); i != priv->ipcSockets.end(); i++)
     (*i)->startPoll(loop);
 
+  uv_signal_start (&priv->signal, handle_trap, SIGCHLD);
   ptrace (PTRACE_CONT, priv->pid, 0, 0);
 }

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -446,22 +446,22 @@ handle_trap(uv_signal_t *handle, int signum)
         priv->handleSeccompEvent();
         ptrace (PTRACE_CONT, priv->pid, 0, 0);
       } else if (s == PTRACE_EVENT_EXIT) {
-          ptrace (PTRACE_GETEVENTMSG, priv->pid, 0, &status);
-          if (WIFSIGNALED (status) && WTERMSIG (status) == SIGSYS) {
-            struct user_regs_struct regs;
-            ptrace (PTRACE_GETREGS, priv->pid, 0, &regs);
-            std::cout << "died on bad syscall " << regs.orig_rax << std::endl;
-            ptrace (PTRACE_CONT, priv->pid, 0, 0);
+        ptrace (PTRACE_GETEVENTMSG, priv->pid, 0, &status);
+        if (WIFSIGNALED (status) && WTERMSIG (status) == SIGSYS) {
+          struct user_regs_struct regs;
+          ptrace (PTRACE_GETREGS, priv->pid, 0, &regs);
+          std::cout << "died on bad syscall " << regs.orig_rax << std::endl;
+          ptrace (PTRACE_CONT, priv->pid, 0, 0);
+        } else {
+          if (WIFSIGNALED (status)) {
+            priv->d->handleSignal (WTERMSIG (status));
+            priv->d->handleExit (WTERMSIG (status));
           } else {
-            if (WIFSIGNALED (status)) {
-              priv->d->handleSignal (WTERMSIG (status));
-              priv->d->handleExit (WTERMSIG (status));
-            } else {
-              assert (WIFEXITED (status));
-              priv->d->handleExit (WEXITSTATUS (status));
-            }
-            priv->d->releaseChild(0);
+            assert (WIFEXITED (status));
+            priv->d->handleExit (WEXITSTATUS (status));
           }
+          priv->d->releaseChild(0);
+        }
       } else if (s == PTRACE_EVENT_EXEC) {
         priv->handleExecEvent();
         ptrace (PTRACE_CONT, priv->pid, 0, 0);


### PR DESCRIPTION
Various cleanups to the code:
- Faster copyString by reading entire words at a time from child memory
- Closing all unused FDs on exec
- Handling SIGABRT as a cue to launch the debugger
- Adding *nanosleep, madvise and exit_group to syscall whitelist
- Printing a message when a process is killed by SIGSYS as a result of using disallowed syscalls
- Starting the signal handler after opening sockets to delay that action as long as possible
- Fixing overwriting beyond a child's buffer in writeData
