### PR TITLE
Implement a virtual filesystem layer

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -86,7 +86,8 @@
           'src/sandbox.cpp',
           'src/sandbox-ipc.cpp',
           'src/vfs.cpp',
-          'src/dirent-builder.cpp'
+          'src/dirent-builder.cpp',
+          'src/native-filesystem.cpp'
         ],
         'include_dirs': [
           'include',

--- a/binding.gyp
+++ b/binding.gyp
@@ -26,7 +26,8 @@
     },
     { 'target_name': 'node-codius-sandbox',
       'sources': [
-        'src/sandbox-node-module.cpp'
+        'src/sandbox-node-module.cpp',
+        'src/node-filesystem.cpp',
       ],
       'include_dirs': [
         'include'

--- a/binding.gyp
+++ b/binding.gyp
@@ -84,7 +84,8 @@
         'sources': [
           'src/sandbox.cpp',
           'src/sandbox-ipc.cpp',
-          'src/vfs.cpp'
+          'src/vfs.cpp',
+          'src/dirent-builder.cpp'
         ],
         'include_dirs': [
           'include',

--- a/binding.gyp
+++ b/binding.gyp
@@ -82,7 +82,8 @@
         'type': 'static_library',
         'sources': [
           'src/sandbox.cpp',
-          'src/sandbox-ipc.cpp'
+          'src/sandbox-ipc.cpp',
+          'src/vfs.cpp'
         ],
         'include_dirs': [
           'include',

--- a/doc/cpp.rst
+++ b/doc/cpp.rst
@@ -18,3 +18,21 @@ The ``CallbackIPC`` class
 .. doxygenclass:: CallbackIPC
   :members:
   :undoc-members:
+
+The ``VFS`` class
++++++++++++++++++
+.. doxygenclass:: VFS
+  :members:
+  :undoc-members:
+
+The ``Filesystem`` class
+++++++++++++++++++++++++
+.. doxygenclass:: Filesystem
+  :members:
+  :undoc-members:
+
+The ``NativeFilesystem`` class
+++++++++++++++++++++++++++++++
+.. doxygenclass:: NativeFilesystem
+  :members:
+  :undoc-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,6 @@ Contents:
    codius-ipc
 
 
-
 Indices and tables
 ==================
 

--- a/doc/node.rst
+++ b/doc/node.rst
@@ -29,6 +29,16 @@ The ``Sandbox`` class
   limited to: war, pestilance, spoilage of all the cheese in your home, a strong
   desire to port Emacs to Node.js.
 
+.. js:function:: Sandbox.onVFS(cookie, op, [...])
+
+  :param object cookie: An opaque cookie that must be later passed to
+  Sandbox.finishVFS()
+  :param string op: Method being called
+
+  Called when a VFS operation occurs.
+
+  Do not touch the cookie. Seriously.
+
 .. js:function:: Sandbox.finishIPC(cookie, result)
 
   :param object cookie: The opaque cookie from Sandbox.onIPC() that was not

--- a/doc/syscalls.rst
+++ b/doc/syscalls.rst
@@ -15,16 +15,19 @@ dependent on any virtual filesystems that are mounted:
 - close
 - ioctl
 - fstat
+- lstat
 - lseek
 - write
 - getdents
 - getdents64
+- readdir
 - readv
 - writev
 - getcwd
 - fcntl
 - chdir
 - fchdir
+- readlink
 
 Networking emulation layer:
 
@@ -54,6 +57,9 @@ Queries about the sandbox system:
 
 The following syscalls pass through the sandbox directly to the kernel:
 
+- fsync
+- fdatasync
+- sync
 - poll
 - mmap
 - mprotect
@@ -88,3 +94,4 @@ The following syscalls pass through the sandbox directly to the kernel:
 - epoll_create1
 - pipe2
 - futex
+- set_tid_address

--- a/doc/syscalls.rst
+++ b/doc/syscalls.rst
@@ -33,7 +33,6 @@ Networking emulation layer:
 - bind
 - setsockopt
 - getsockname
-- getsockname
 - getpeername
 - getsockopt
 

--- a/include/dirent-builder.h
+++ b/include/dirent-builder.h
@@ -1,0 +1,29 @@
+#ifndef DIRENT_BUILDER_H
+#define DIRENT_BUILDER_H
+
+#include <vector>
+#include <string>
+
+struct linux_dirent {
+  unsigned long d_ino;
+  unsigned long d_off;
+  unsigned short d_reclen;
+  char d_name[];
+  /*
+   * char d_type;
+   */
+};
+
+class DirentBuilder {
+public:
+  DirentBuilder(int startIdx = 1);
+  void append(const std::string& name);
+  std::vector<char> data() const;
+
+private:
+  std::vector<char> m_buf;
+  int m_idx;
+  int m_inode;
+};
+
+#endif // DIRENT_BUILDER_H

--- a/include/dirent-builder.h
+++ b/include/dirent-builder.h
@@ -1,6 +1,7 @@
 #ifndef DIRENT_BUILDER_H
 #define DIRENT_BUILDER_H
 
+#include <dirent.h>
 #include <vector>
 #include <string>
 
@@ -16,8 +17,19 @@ struct linux_dirent {
 
 class DirentBuilder {
 public:
+  enum DirentType {
+    Unknown = DT_UNKNOWN,
+    FIFO = DT_FIFO,
+    Character = DT_CHR,
+    Directory = DT_DIR,
+    Block = DT_BLK,
+    Regular = DT_REG,
+    Link = DT_LNK,
+    Socket = DT_SOCK
+  };
+
   DirentBuilder(int startIdx = 1);
-  void append(const std::string& name);
+  void append(const std::string& name, DirentType type = Regular);
   std::vector<char> data() const;
 
 private:

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -23,6 +23,7 @@ public:
   virtual int access(const char* name, int mode) = 0;
   virtual int stat(const char* path, struct stat *buf) = 0;
   virtual int lstat(const char* path, struct stat *buf) = 0;
+  virtual ssize_t readlink(const char* path, char* buf, size_t bufsize) = 0;
 };
 
 #endif // FILESYSTEM_H

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -21,6 +21,8 @@ public:
   virtual off_t lseek(int fd, off_t offset, int whence) = 0;
   virtual ssize_t write(int fd, void* buf, size_t count) = 0;
   virtual int access(const char* name, int mode) = 0;
+  virtual int stat(const char* path, struct stat *buf) = 0;
+  virtual int lstat(const char* path, struct stat *buf) = 0;
 };
 
 #endif // FILESYSTEM_H

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -3,6 +3,14 @@
 
 #include <unistd.h>
 
+/**
+ * Interface for implementing concrete filesystems
+ *
+ * Each function is an implementation of a specific POSIX syscall.
+ *
+ * @see VFS
+ * @see Syscall manpages
+ */
 class Filesystem {
 public:
   virtual int open(const char* name, int flags) = 0;

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -13,7 +13,7 @@
  */
 class Filesystem {
 public:
-  virtual int open(const char* name, int flags) = 0;
+  virtual int open(const char* name, int flags, int mode) = 0;
   virtual ssize_t read(int fd, void* buf, size_t count) = 0;
   virtual int close(int fd) = 0;
   virtual int fstat(int fd, struct stat* buf) = 0;

--- a/include/filesystem.h
+++ b/include/filesystem.h
@@ -1,0 +1,18 @@
+#ifndef FILESYSTEM_H
+#define FILESYSTEM_H
+
+#include <unistd.h>
+
+class Filesystem {
+public:
+  virtual int open(const char* name, int flags) = 0;
+  virtual ssize_t read(int fd, void* buf, size_t count) = 0;
+  virtual int close(int fd) = 0;
+  virtual int fstat(int fd, struct stat* buf) = 0;
+  virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count) = 0;
+  virtual off_t lseek(int fd, off_t offset, int whence) = 0;
+  virtual ssize_t write(int fd, void* buf, size_t count) = 0;
+  virtual int access(const char* name, int mode) = 0;
+};
+
+#endif // FILESYSTEM_H

--- a/include/native-filesystem.h
+++ b/include/native-filesystem.h
@@ -26,6 +26,7 @@ public:
   virtual int access(const char* name, int mode);
   virtual int stat(const char* path, struct stat* buf);
   virtual int lstat(const char* path, struct stat* buf);
+  virtual ssize_t readlink(const char* path, char* buf, size_t bufsize);
 
 private:
   std::string m_root;

--- a/include/native-filesystem.h
+++ b/include/native-filesystem.h
@@ -1,0 +1,25 @@
+#ifndef NATIVE_FILESYSTEM_H
+#define NATIVE_FILESYSTEM_H
+
+#include "filesystem.h"
+#include <string>
+#include <map>
+
+class NativeFilesystem : public Filesystem {
+public:
+  NativeFilesystem(const std::string& root);
+  virtual int open(const char* name, int flags);
+  virtual ssize_t read(int fd, void* buf, size_t count);
+  virtual int close(int fd);
+  virtual int fstat(int fd, struct stat* buf);
+  virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count);
+  virtual off_t lseek(int fd, off_t offset, int whence);
+  virtual ssize_t write(int fd, void* buf, size_t count);
+  virtual int access(const char* name, int mode);
+
+private:
+  std::string m_root;
+  std::map<int, std::string> m_openFiles;
+};
+
+#endif // NATIVE_FILESYSTEM_H

--- a/include/native-filesystem.h
+++ b/include/native-filesystem.h
@@ -24,6 +24,8 @@ public:
   virtual off_t lseek(int fd, off_t offset, int whence);
   virtual ssize_t write(int fd, void* buf, size_t count);
   virtual int access(const char* name, int mode);
+  virtual int stat(const char* path, struct stat* buf);
+  virtual int lstat(const char* path, struct stat* buf);
 
 private:
   std::string m_root;

--- a/include/native-filesystem.h
+++ b/include/native-filesystem.h
@@ -16,7 +16,7 @@ public:
    * @param root Root of this filesystem
    */
   NativeFilesystem(const std::string& root);
-  virtual int open(const char* name, int flags);
+  virtual int open(const char* name, int flags, int mode);
   virtual ssize_t read(int fd, void* buf, size_t count);
   virtual int close(int fd);
   virtual int fstat(int fd, struct stat* buf);

--- a/include/native-filesystem.h
+++ b/include/native-filesystem.h
@@ -5,8 +5,16 @@
 #include <string>
 #include <map>
 
+/**
+ * A filesystem that directly interacts with the host's local filesystem
+ */
 class NativeFilesystem : public Filesystem {
 public:
+  /**
+   * Constructor. Accepts a path that is the root of this filesystem
+   *
+   * @param root Root of this filesystem
+   */
   NativeFilesystem(const std::string& root);
   virtual int open(const char* name, int flags);
   virtual ssize_t read(int fd, void* buf, size_t count);

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -1,0 +1,32 @@
+#ifndef NODE_FILESYSTEM_H
+#define NODE_FILESYSTEM_H
+
+#include "vfs.h"
+
+#include <node.h>
+
+class NodeSandbox;
+
+class CodiusNodeFilesystem : public Filesystem {
+public:
+  CodiusNodeFilesystem(NodeSandbox* sbox);
+
+  struct VFSResult {
+    int errnum;
+    v8::Handle<v8::Value> result;
+  };
+
+  VFSResult doVFS(const std::string& name, v8::Handle<v8::Value> argv[], int argc);
+
+  int open(const char* name, int flags);
+  ssize_t read(int fd, void* buf, size_t count);
+  int close (int fd);
+  int fstat (int fd, struct stat* buf);
+  int getdents (int fd, struct linux_dirent* dirs, unsigned int count);
+  int openat (int fd, const char* filename, int flags, mode_t mode);
+
+private:
+  NodeSandbox* m_sbox;
+};
+
+#endif // NODE_FILESYSTEM_H

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -23,6 +23,7 @@ public:
   int close (int fd) override;
   int fstat (int fd, struct stat* buf) override;
   int getdents (int fd, struct linux_dirent* dirs, unsigned int count) override;
+  off_t lseek (int fd, off_t offset, int whence) override;
 
 private:
   NodeSandbox* m_sbox;

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -26,6 +26,8 @@ public:
   off_t lseek (int fd, off_t offset, int whence) override;
   ssize_t write(int fd, void* buf, size_t count) override;
   int access (const char* name, int mode) override;
+  int stat (const char* name, struct stat* buf) override;
+  int lstat (const char* name, struct stat* buf) override;
 
 private:
   NodeSandbox* m_sbox;

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -18,7 +18,7 @@ public:
 
   VFSResult doVFS(const std::string& name, v8::Handle<v8::Value> argv[], int argc);
 
-  int open(const char* name, int flags) override;
+  int open(const char* name, int flags, int mode) override;
   ssize_t read(int fd, void* buf, size_t count) override;
   int close (int fd) override;
   int fstat (int fd, struct stat* buf) override;

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -24,6 +24,8 @@ public:
   int fstat (int fd, struct stat* buf) override;
   int getdents (int fd, struct linux_dirent* dirs, unsigned int count) override;
   off_t lseek (int fd, off_t offset, int whence) override;
+  ssize_t write(int fd, void* buf, size_t count) override;
+  int access (const char* name, int mode) override;
 
 private:
   NodeSandbox* m_sbox;

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -28,6 +28,7 @@ public:
   int access (const char* name, int mode) override;
   int stat (const char* name, struct stat* buf) override;
   int lstat (const char* name, struct stat* buf) override;
+  ssize_t readlink(const char* path, char* buf, size_t bufsize);
 
 private:
   NodeSandbox* m_sbox;

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -32,6 +32,7 @@ public:
 
 private:
   NodeSandbox* m_sbox;
+  std::map<int, int> m_offsets;
 };
 
 #endif // NODE_FILESYSTEM_H

--- a/include/node-filesystem.h
+++ b/include/node-filesystem.h
@@ -18,12 +18,11 @@ public:
 
   VFSResult doVFS(const std::string& name, v8::Handle<v8::Value> argv[], int argc);
 
-  int open(const char* name, int flags);
-  ssize_t read(int fd, void* buf, size_t count);
-  int close (int fd);
-  int fstat (int fd, struct stat* buf);
-  int getdents (int fd, struct linux_dirent* dirs, unsigned int count);
-  int openat (int fd, const char* filename, int flags, mode_t mode);
+  int open(const char* name, int flags) override;
+  ssize_t read(int fd, void* buf, size_t count) override;
+  int close (int fd) override;
+  int fstat (int fd, struct stat* buf) override;
+  int getdents (int fd, struct linux_dirent* dirs, unsigned int count) override;
 
 private:
   NodeSandbox* m_sbox;

--- a/include/node-sandbox.h
+++ b/include/node-sandbox.h
@@ -26,7 +26,10 @@ public:
   void emitEvent(const std::string& name, std::vector<v8::Handle<v8::Value> >& argv);
   SyscallCall mapFilename(const SyscallCall& call);
   SyscallCall handleSyscall(const SyscallCall &call) override;
-  std::future<v8::Persistent<v8::Value> > doVFS(const std::string& name, v8::Handle<v8::Value> argv[], int argc);
+
+  using VFSPromise = std::promise<v8::Persistent<v8::Value> >;
+  using VFSFuture = std::shared_future<v8::Persistent<v8::Value> >;
+  VFSFuture doVFS(const std::string& name, v8::Handle<v8::Value> argv[], int argc);
 
   void handleIPC(codius_request_t* request) override;
   void handleExit(int status) override;

--- a/include/node-sandbox.h
+++ b/include/node-sandbox.h
@@ -1,0 +1,50 @@
+#ifndef NODE_SANDBOX_H
+#define NODE_SANDBOX_H
+
+#include "sandbox.h"
+#include <node.h>
+#include <memory>
+#include <vector>
+#include <future>
+
+class NodeSandbox;
+
+class SandboxWrapper : public node::ObjectWrap {
+  public:
+    SandboxWrapper();
+    ~SandboxWrapper();
+    std::unique_ptr<NodeSandbox> sbox;
+    v8::Persistent<v8::Object> nodeThis;
+    friend class NodeSandbox;
+};
+
+class NodeSandbox : public Sandbox {
+public:
+  NodeSandbox(SandboxWrapper* _wrap);
+
+  std::vector<char> mapFilename(std::vector<char> fname);
+  void emitEvent(const std::string& name, std::vector<v8::Handle<v8::Value> >& argv);
+  SyscallCall mapFilename(const SyscallCall& call);
+  SyscallCall handleSyscall(const SyscallCall &call) override;
+  std::future<v8::Persistent<v8::Value> > doVFS(const std::string& name, v8::Handle<v8::Value> argv[], int argc);
+
+  void handleIPC(codius_request_t* request) override;
+  void handleExit(int status) override;
+  void launchDebugger();
+  void handleSignal(int signal) override;
+  static void Init(v8::Handle<v8::Object> exports);
+  SandboxWrapper* wrap;
+
+private:
+    bool m_debuggerOnCrash;
+    static v8::Handle<v8::Value> node_spawn(const v8::Arguments& args);
+    static v8::Handle<v8::Value> node_kill(const v8::Arguments& args);
+    static v8::Handle<v8::Value> node_finish_ipc(const v8::Arguments& args);
+    static v8::Handle<v8::Value> node_finish_vfs(const v8::Arguments& args);
+    static v8::Handle<v8::Value> node_new(const v8::Arguments& args);
+    static v8::Handle<v8::Value> node_getDebugOnCrash(v8::Local<v8::String> property, const v8::AccessorInfo& info);
+    static void node_setDebugOnCrash(v8::Local<v8::String> property, v8::Local<v8::Value> value, const v8::AccessorInfo& info);
+    static v8::Persistent<v8::Function> s_constructor;
+};
+
+#endif // NODE_SANDBOX_H

--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -2,6 +2,7 @@
 #define CODIUS_SANDBOX_H
 
 #include <map>
+#include <vector>
 #include <unistd.h>
 #include <memory>
 #include <string>

--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -122,7 +122,7 @@ class Sandbox {
      * @return @p true if successful, @p false otherwise. @p errno will be set
      * upon failure.
      */
-    bool copyString (Address addr, int maxLength, char* buf);
+    bool copyString (Address addr, size_t maxLength, char* buf);
 
     /**
      * Write a single word to the child process' memory

--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -170,11 +170,6 @@ class Sandbox {
     pid_t getChildPID() const;
 
     /**
-     * Returns the child's current directory
-     */
-    std::string getCWD() const;
-
-    /**
      * Returns true after the child has called execve()
      */
     bool enteredMain() const;

--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -166,6 +166,11 @@ class Sandbox {
     pid_t getChildPID() const;
 
     /**
+     * Returns the child's current directory
+     */
+    std::string getCWD() const;
+
+    /**
      * Returns true after the child has called execve()
      */
     bool enteredMain() const;

--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -8,6 +8,7 @@
 
 class SandboxPrivate;
 class SandboxIPC;
+class VFS;
 
 //FIXME: This shouldn't be public API. It is only used for libuv
 struct SandboxWrap {
@@ -191,6 +192,9 @@ class Sandbox {
      * Kills the child process with SIGKILL
      */
     void kill();
+    
+    VFS& getVFS() const;
+
 
   private:
     SandboxPrivate* m_p;

--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <unistd.h>
 #include <memory>
+#include <string>
 #include "codius-util.h"
 
 class SandboxPrivate;

--- a/include/sandbox.h
+++ b/include/sandbox.h
@@ -48,6 +48,8 @@ class Sandbox {
          * Arguments to the syscall
          */
         Word args[6];
+
+        Word returnVal;
     };
 
     /**

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -135,6 +135,8 @@ private:
   void do_access(Sandbox::SyscallCall& call);
   void do_chdir(Sandbox::SyscallCall& call);
   void do_fchdir(Sandbox::SyscallCall& call);
+  void do_stat(Sandbox::SyscallCall& call);
+  void do_lstat(Sandbox::SyscallCall& call);
 
   File::Ptr makeFile (int fd, const std::string& path, std::shared_ptr<Filesystem>& fs);
 };

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -24,6 +24,7 @@ public:
   int getdents(struct linux_dirent* dirs, unsigned int count);
   ssize_t read(void* buf, size_t count);
   off_t lseek(off_t offset, int whence);
+  ssize_t write(void* buf, size_t count);
 
   std::string path() const;
 
@@ -45,6 +46,8 @@ public:
   virtual int fstat(int fd, struct stat* buf) = 0;
   virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count) = 0;
   virtual off_t lseek(int fd, off_t offset, int whence) = 0;
+  virtual ssize_t write(int fd, void* buf, size_t count) = 0;
+  virtual int access(const char* name, int mode) = 0;
 };
 
 class NativeFilesystem : public Filesystem {
@@ -56,6 +59,8 @@ public:
   virtual int fstat(int fd, struct stat* buf);
   virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count);
   virtual off_t lseek(int fd, off_t offset, int whence);
+  virtual ssize_t write(int fd, void* buf, size_t count);
+  virtual int access(const char* name, int mode);
 
 private:
   std::string m_root;
@@ -92,6 +97,8 @@ private:
   void do_getdents(Sandbox::SyscallCall& call);
   void do_openat(Sandbox::SyscallCall& call);
   void do_lseek(Sandbox::SyscallCall& call);
+  void do_write(Sandbox::SyscallCall& call);
+  void do_access(Sandbox::SyscallCall& call);
 
   File::Ptr makeFile (int fd, const std::string& path, std::shared_ptr<Filesystem>& fs);
 };

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -12,11 +12,27 @@ class Filesystem {
 public:
   Filesystem();
 
-  int open(const char* name, int flags);
-  ssize_t read(int fd, void* buf, size_t count);
-  int close(int fd);
-  int fstat(int fd, struct stat* buf);
-  void getdents(int fd, DirentBuilder& builder);
+  virtual int open(const char* name, int flags) = 0;
+  virtual ssize_t read(int fd, void* buf, size_t count) = 0;
+  virtual int close(int fd) = 0;
+  virtual int fstat(int fd, struct stat* buf) = 0;
+  virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count) = 0;
+  virtual int openat(int fd, const char* filename, int flags, mode_t mode) = 0;
+};
+
+class NativeFilesystem : public Filesystem {
+public:
+  NativeFilesystem(const std::string& root);
+  virtual int open(const char* name, int flags);
+  virtual ssize_t read(int fd, void* buf, size_t count);
+  virtual int close(int fd);
+  virtual int fstat(int fd, struct stat* buf);
+  virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count);
+  virtual int openat(int fd, const char* filename, int flags, mode_t mode);
+
+private:
+  std::string m_root;
+  std::map<int, std::string> m_openFiles;
 };
 
 class VFS {
@@ -40,6 +56,7 @@ private:
   void do_read(Sandbox::SyscallCall& call);
   void do_fstat(Sandbox::SyscallCall& call);
   void do_getdents(Sandbox::SyscallCall& call);
+  void do_openat(Sandbox::SyscallCall& call);
 };
 
 #endif // VFS_H

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -44,7 +44,7 @@ public:
   /**
    * Constructor
    *
-   * @param sandbox Sandbox this VFS Is attached to
+   * @param sandbox Sandbox this VFS is attached to
    */
   VFS(Sandbox* sandbox);
 

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -137,6 +137,8 @@ private:
   void do_fchdir(Sandbox::SyscallCall& call);
   void do_stat(Sandbox::SyscallCall& call);
   void do_lstat(Sandbox::SyscallCall& call);
+  void do_getcwd(Sandbox::SyscallCall& call);
+  void do_readlink(Sandbox::SyscallCall& call);
 
   File::Ptr makeFile (int fd, const std::string& path, std::shared_ptr<Filesystem>& fs);
 };

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -122,6 +122,8 @@ private:
 
   bool isWhitelisted(const std::string& str);
 
+  void openFile(Sandbox::SyscallCall& call, const std::string& fname);
+
   void do_open(Sandbox::SyscallCall& call);
   void do_close(Sandbox::SyscallCall& call);
   void do_read(Sandbox::SyscallCall& call);

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -1,12 +1,12 @@
 #ifndef VFS_H
 #define VFS_H
 
+#include "dirent-builder.h"
 #include "sandbox.h"
 #include <memory>
 #include <vector>
 
 class Filesystem;
-class DirentBuilder;
 
 class Filesystem {
 public:

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -122,7 +122,7 @@ private:
 
   bool isWhitelisted(const std::string& str);
 
-  void openFile(Sandbox::SyscallCall& call, const std::string& fname);
+  void openFile(Sandbox::SyscallCall& call, const std::string& fname, int flags, mode_t mode);
 
   void do_open(Sandbox::SyscallCall& call);
   void do_close(Sandbox::SyscallCall& call);

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -3,10 +3,10 @@
 
 #include "dirent-builder.h"
 #include "sandbox.h"
+#include "filesystem.h"
+
 #include <memory>
 #include <vector>
-
-class Filesystem;
 
 class File {
 public:
@@ -34,37 +34,6 @@ private:
   int m_virtualFD;
   std::string m_path;
   std::shared_ptr<Filesystem> m_fs;
-};
-
-class Filesystem {
-public:
-  Filesystem();
-
-  virtual int open(const char* name, int flags) = 0;
-  virtual ssize_t read(int fd, void* buf, size_t count) = 0;
-  virtual int close(int fd) = 0;
-  virtual int fstat(int fd, struct stat* buf) = 0;
-  virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count) = 0;
-  virtual off_t lseek(int fd, off_t offset, int whence) = 0;
-  virtual ssize_t write(int fd, void* buf, size_t count) = 0;
-  virtual int access(const char* name, int mode) = 0;
-};
-
-class NativeFilesystem : public Filesystem {
-public:
-  NativeFilesystem(const std::string& root);
-  virtual int open(const char* name, int flags);
-  virtual ssize_t read(int fd, void* buf, size_t count);
-  virtual int close(int fd);
-  virtual int fstat(int fd, struct stat* buf);
-  virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count);
-  virtual off_t lseek(int fd, off_t offset, int whence);
-  virtual ssize_t write(int fd, void* buf, size_t count);
-  virtual int access(const char* name, int mode);
-
-private:
-  std::string m_root;
-  std::map<int, std::string> m_openFiles;
 };
 
 class VFS {

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -82,11 +82,15 @@ public:
   void mountFilesystem(const std::string& path, std::shared_ptr<Filesystem> fs);
   std::string getMountedFilename(const std::string& path) const;
 
+  std::string getCWD() const;
+  int setCWD(const std::string& str);
+
 private:
   Sandbox* m_sbox;
   std::map<std::string, std::shared_ptr <Filesystem>> m_mountpoints;
   std::map<int, File::Ptr> m_openFiles;
   std::vector<std::string> m_whitelist;
+  File::Ptr m_cwd;
 
   bool isWhitelisted(const std::string& str);
 
@@ -99,6 +103,8 @@ private:
   void do_lseek(Sandbox::SyscallCall& call);
   void do_write(Sandbox::SyscallCall& call);
   void do_access(Sandbox::SyscallCall& call);
+  void do_chdir(Sandbox::SyscallCall& call);
+  void do_fchdir(Sandbox::SyscallCall& call);
 
   File::Ptr makeFile (int fd, const std::string& path, std::shared_ptr<Filesystem>& fs);
 };

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -41,10 +41,16 @@ public:
 
   Sandbox::SyscallCall handleSyscall(const Sandbox::SyscallCall& call);
   std::string getFilename(Sandbox::Address addr) const;
+  std::pair<std::string, std::shared_ptr<Filesystem> > getFilesystem(const std::string& path) const;
+  std::shared_ptr<Filesystem> getFilesystem(int fd) const;
+
+  void mountFilesystem(const std::string& path, std::shared_ptr<Filesystem> fs);
+  std::string getMountedFilename(const std::string& path) const;
 
 private:
   Sandbox* m_sbox;
-  std::unique_ptr<Filesystem> m_fs;
+  std::map<std::string, std::shared_ptr <Filesystem>> m_mountpoints;
+  std::map<int, std::shared_ptr<Filesystem>> m_openFiles;
   std::vector<std::string> m_whitelist;
 
   bool isWhitelisted(const std::string& str);

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -5,6 +5,20 @@
 #include <memory>
 #include <vector>
 
+class Filesystem;
+class DirentBuilder;
+
+class Filesystem {
+public:
+  Filesystem();
+
+  int open(const char* name, int flags);
+  ssize_t read(int fd, void* buf, size_t count);
+  int close(int fd);
+  int fstat(int fd, struct stat* buf);
+  void getdents(int fd, DirentBuilder& builder);
+};
+
 class VFS {
 public:
   VFS(Sandbox* sandbox);
@@ -13,9 +27,19 @@ public:
   std::string getFilename(Sandbox::Address addr) const;
 
 private:
+  Sandbox* m_sbox;
+  std::unique_ptr<Filesystem> m_fs;
+  std::vector<std::string> m_whitelist;
+
+  bool isWhitelisted(const std::string& str);
   int fromVirtualFD(int fd);
   int toVirtualFD(int fd);
-  Sandbox* m_sbox;
+
+  void do_open(Sandbox::SyscallCall& call);
+  void do_close(Sandbox::SyscallCall& call);
+  void do_read(Sandbox::SyscallCall& call);
+  void do_fstat(Sandbox::SyscallCall& call);
+  void do_getdents(Sandbox::SyscallCall& call);
 };
 
 #endif // VFS_H

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -1,0 +1,21 @@
+#ifndef VFS_H
+#define VFS_H
+
+#include "sandbox.h"
+#include <memory>
+#include <vector>
+
+class VFS {
+public:
+  VFS(Sandbox* sandbox);
+
+  Sandbox::SyscallCall handleSyscall(const Sandbox::SyscallCall& call);
+  std::string getFilename(Sandbox::Address addr) const;
+
+private:
+  int fromVirtualFD(int fd);
+  int toVirtualFD(int fd);
+  Sandbox* m_sbox;
+};
+
+#endif // VFS_H

--- a/include/vfs.h
+++ b/include/vfs.h
@@ -23,6 +23,7 @@ public:
   int fstat(struct stat* buf);
   int getdents(struct linux_dirent* dirs, unsigned int count);
   ssize_t read(void* buf, size_t count);
+  off_t lseek(off_t offset, int whence);
 
   std::string path() const;
 
@@ -43,6 +44,7 @@ public:
   virtual int close(int fd) = 0;
   virtual int fstat(int fd, struct stat* buf) = 0;
   virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count) = 0;
+  virtual off_t lseek(int fd, off_t offset, int whence) = 0;
 };
 
 class NativeFilesystem : public Filesystem {
@@ -53,6 +55,7 @@ public:
   virtual int close(int fd);
   virtual int fstat(int fd, struct stat* buf);
   virtual int getdents(int fd, struct linux_dirent* dirs, unsigned int count);
+  virtual off_t lseek(int fd, off_t offset, int whence);
 
 private:
   std::string m_root;
@@ -88,6 +91,7 @@ private:
   void do_fstat(Sandbox::SyscallCall& call);
   void do_getdents(Sandbox::SyscallCall& call);
   void do_openat(Sandbox::SyscallCall& call);
+  void do_lseek(Sandbox::SyscallCall& call);
 
   File::Ptr makeFile (int fd, const std::string& path, std::shared_ptr<Filesystem>& fs);
 };

--- a/src/dirent-builder.cpp
+++ b/src/dirent-builder.cpp
@@ -9,9 +9,8 @@ DirentBuilder::DirentBuilder(int startIdx)
     m_inode (256)
 {}
 
-//FIXME: This needs to be able to support non-regular file types
 void
-DirentBuilder::append(const std::string& name) {
+DirentBuilder::append(const std::string& name, DirentType type) {
   unsigned short reclen = 24;
   unsigned short min_reclen;
 
@@ -28,7 +27,7 @@ DirentBuilder::append(const std::string& name) {
   ent->d_reclen = reclen;
   memcpy (ent->d_name, name.c_str(), name.size());
   m_buf.data()[start + min_reclen - 2] = 0;
-  m_buf.data()[start + reclen - 1] = 4;
+  m_buf.data()[start + reclen - 1] = type;
 }
 
 std::vector<char>

--- a/src/dirent-builder.cpp
+++ b/src/dirent-builder.cpp
@@ -1,0 +1,38 @@
+#include "dirent-builder.h"
+
+#include <memory.h>
+#include <dirent.h>
+#include <iostream>
+
+DirentBuilder::DirentBuilder(int startIdx)
+  : m_idx (startIdx),
+    m_inode (256)
+{}
+
+//FIXME: This needs to be able to support non-regular file types
+void
+DirentBuilder::append(const std::string& name) {
+  unsigned short reclen = 24;
+  unsigned short min_reclen;
+
+  min_reclen = sizeof (((linux_dirent*)0)->d_ino) + sizeof (((linux_dirent*)0)->d_off) + sizeof (((linux_dirent*)0)->d_reclen) + name.size() + 2;
+  while (reclen < min_reclen) {
+    reclen += 8;
+  }
+  off_t start = m_buf.size();
+  m_buf.resize (start + reclen);
+  memset (&m_buf.data()[start], 0, reclen);
+  linux_dirent* ent = reinterpret_cast<linux_dirent*>(&m_buf.data()[start]);
+  ent->d_ino = m_inode++;
+  ent->d_off = m_idx++;
+  ent->d_reclen = reclen;
+  memcpy (ent->d_name, name.c_str(), name.size());
+  m_buf.data()[start + min_reclen - 2] = 0;
+  m_buf.data()[start + reclen - 1] = 4;
+}
+
+std::vector<char>
+DirentBuilder::data() const {
+  return m_buf;
+}
+

--- a/src/native-filesystem.cpp
+++ b/src/native-filesystem.cpp
@@ -1,0 +1,63 @@
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "native-filesystem.h"
+
+int
+NativeFilesystem::open(const char* name, int flags)
+{
+  std::string newName (name);
+  newName = m_root + "/" + newName;
+  return ::open (newName.c_str(), flags);
+}
+
+int
+NativeFilesystem::close(int fd)
+{
+  return ::close (fd);
+}
+
+ssize_t
+NativeFilesystem::read(int fd, void* buf, size_t count)
+{
+  return ::read (fd, buf, count);
+}
+
+int
+NativeFilesystem::fstat(int fd, struct stat* buf)
+{
+  return ::fstat (fd, buf);
+}
+
+int
+NativeFilesystem::getdents(int fd, struct linux_dirent* dirs, unsigned int count)
+{
+  return ::syscall (SYS_getdents, fd, dirs, count);
+}
+
+off_t
+NativeFilesystem::lseek(int fd, off_t offset, int whence)
+{
+  return ::lseek (fd, offset, whence);
+}
+
+NativeFilesystem::NativeFilesystem(const std::string& root)
+  : Filesystem()
+  , m_root (root)
+{
+}
+
+ssize_t
+NativeFilesystem::write(int fd, void* buf, size_t count)
+{
+  return ::write (fd, buf, count);
+}
+
+int
+NativeFilesystem::access(const char* name, int mode)
+{
+  return ::access (name, mode);
+}
+

--- a/src/native-filesystem.cpp
+++ b/src/native-filesystem.cpp
@@ -61,3 +61,14 @@ NativeFilesystem::access(const char* name, int mode)
   return ::access (name, mode);
 }
 
+int
+NativeFilesystem::stat(const char* name, struct stat* buf)
+{
+  return ::stat (name, buf);
+}
+
+int
+NativeFilesystem::lstat(const char* name, struct stat* buf)
+{
+  return ::lstat (name, buf);
+}

--- a/src/native-filesystem.cpp
+++ b/src/native-filesystem.cpp
@@ -6,11 +6,11 @@
 #include "native-filesystem.h"
 
 int
-NativeFilesystem::open(const char* name, int flags)
+NativeFilesystem::open(const char* name, int flags, int mode)
 {
   std::string newName (name);
   newName = m_root + "/" + newName;
-  return ::open (newName.c_str(), flags);
+  return ::open (newName.c_str(), flags, mode);
 }
 
 int

--- a/src/native-filesystem.cpp
+++ b/src/native-filesystem.cpp
@@ -72,3 +72,9 @@ NativeFilesystem::lstat(const char* name, struct stat* buf)
 {
   return ::lstat (name, buf);
 }
+
+ssize_t
+NativeFilesystem::readlink(const char* name, char* buf, size_t bufsize)
+{
+  return ::readlink (name, buf, bufsize);
+}

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -129,3 +129,35 @@ CodiusNodeFilesystem::getdents(int fd, struct linux_dirent* dirs, unsigned int c
   memcpy (dirs, buf.data(), buf.size());
   return buf.size();
 }
+
+ssize_t
+CodiusNodeFilesystem::write(int fd, void* buf, size_t count)
+{
+  Handle<Value> argv[] = {
+    Int32::New (fd),
+    String::New ((char*)buf, count)
+  };
+
+  VFSResult ret = doVFS (std::string ("write"), argv, 2);
+
+  if (ret.errnum)
+    return -ret.errnum;
+
+  return ret.result->ToInt32()->Value();
+}
+
+int
+CodiusNodeFilesystem::access (const char* name, int mode)
+{
+  Handle<Value> argv[] = {
+    String::New (name),
+    Int32::New (mode)
+  };
+
+  VFSResult ret = doVFS (std::string ("access"), argv, 2);
+
+  if (ret.errnum)
+    return -ret.errnum;
+
+  return ret.result->ToInt32()->Value();
+}

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -97,6 +97,14 @@ CodiusNodeFilesystem::fstat(int fd, struct stat* buf)
   return -ENOSYS;
 }
 
+off_t
+CodiusNodeFilesystem::lseek(int fd, off_t offset, int whence)
+{
+  // FIXME: node's FS module doesn't implement lseek, but we need it for
+  // rewinddir()
+  return -ENOSYS;
+}
+
 int
 CodiusNodeFilesystem::getdents(int fd, struct linux_dirent* dirs, unsigned int count)
 {

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -166,6 +166,22 @@ CodiusNodeFilesystem::write(int fd, void* buf, size_t count)
   return ret.result->ToInt32()->Value();
 }
 
+ssize_t
+CodiusNodeFilesystem::readlink (const char* path, char* buf, size_t bufsize)
+{
+  Handle<Value> argv[] = {
+    String::New (path)
+  };
+
+  VFSResult ret = doVFS (std::string ("readlink"), argv, 1);
+
+  if (ret.errnum)
+    return -ret.errnum;
+
+  ret.result->ToString()->WriteUtf8 (buf, bufsize);
+  return ret.result->ToString()->Utf8Length();
+}
+
 int
 CodiusNodeFilesystem::access (const char* name, int mode)
 {

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -122,9 +122,3 @@ CodiusNodeFilesystem::getdents(int fd, struct linux_dirent* dirs, unsigned int c
   return buf.size();
 }
 
-int
-CodiusNodeFilesystem::openat(int fd, const char* filename, int flags, mode_t mode)
-{
-  return -ENOSYS;
-}
-

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -1,0 +1,130 @@
+#include "node-filesystem.h"
+#include "node-sandbox.h"
+#include <future>
+#include <iostream>
+#include <memory.h>
+
+using namespace v8;
+
+CodiusNodeFilesystem::CodiusNodeFilesystem(NodeSandbox* sbox)
+  : Filesystem(),
+    m_sbox (sbox) {}
+
+CodiusNodeFilesystem::VFSResult
+CodiusNodeFilesystem::doVFS(const std::string& name, Handle<Value> argv[], int argc)
+{
+  uv_loop_t*  loop = uv_default_loop ();
+  Handle<Value> result;
+  NodeSandbox::VFSFuture ret = m_sbox->doVFS (name, argv, argc);
+
+  while (ret.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+    uv_run (loop, UV_RUN_ONCE);
+
+  result = ret.get();
+
+  if (result->IsObject()) {
+    Handle<Object> resultObj = result->ToObject();
+    int err = resultObj->Get (String::NewSymbol ("error"))->ToInt32()->Value();
+    Handle<Value> resultValue = resultObj->Get (String::NewSymbol ("result"));
+
+    VFSResult r  = {
+      .errnum = err,
+      .result = resultValue
+    };
+
+    return r;
+  }
+
+  ThrowException(Exception::TypeError(String::New("Expected a VFS call return type")));
+
+  VFSResult r = {
+    .errnum = ENOSYS,
+    .result = Undefined()
+  };
+
+  return r;
+}
+
+int
+CodiusNodeFilesystem::open(const char* name, int flags)
+{
+  Handle<Value> argv[] = {
+    String::New (name),
+    Int32::New (flags),
+    Int32::New (0) //FIXME: We also need the mode?
+  };
+
+  VFSResult ret = doVFS(std::string ("open"), argv, 3);
+
+  if (ret.errnum) {
+    return -ret.errnum;
+  }
+
+  return ret.result->ToInt32()->Value();
+}
+
+ssize_t
+CodiusNodeFilesystem::read(int fd, void* buf, size_t count)
+{
+  Handle<Value> argv[] = {
+    Int32::New (fd),
+    Int32::New (count)
+  };
+
+  VFSResult ret = doVFS (std::string ("read"), argv, 2);
+
+  if (ret.errnum)
+    return -ret.errnum;
+
+  ret.result->ToString()->WriteUtf8 (static_cast<char*>(buf), count);
+
+  return ret.result->ToString()->Utf8Length();
+}
+
+int
+CodiusNodeFilesystem::close(int fd)
+{
+  Handle<Value> argv[] = {
+    Int32::New (fd)
+  };
+
+  return -doVFS (std::string ("close"), argv, 1).errnum;
+}
+
+int
+CodiusNodeFilesystem::fstat(int fd, struct stat* buf)
+{
+  return -ENOSYS;
+}
+
+int
+CodiusNodeFilesystem::getdents(int fd, struct linux_dirent* dirs, unsigned int count)
+{
+  Handle<Value> argv[] = {
+    Int32::New (fd)
+  };
+  VFSResult ret = doVFS(std::string ("getdents"), argv, 1);
+  if (ret.errnum)
+    return -ret.errnum;
+
+  DirentBuilder builder;
+
+  Handle<Array> fileList = Handle<Array>::Cast (ret.result);
+  for (uint32_t i = 0; i < fileList->Length(); i++) {
+    Handle<String> filename = fileList->Get(i)->ToString();
+    char buf[filename->Utf8Length()];
+    filename->WriteUtf8 (buf, filename->Utf8Length());
+    builder.append (std::string (buf));
+  }
+  std::vector<char> buf;
+  buf = builder.data();
+  memcpy (dirs, buf.data(), buf.size());
+  return buf.size();
+}
+
+int
+CodiusNodeFilesystem::openat(int fd, const char* filename, int flags, mode_t mode)
+{
+  return -ENOSYS;
+}
+

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -46,12 +46,12 @@ CodiusNodeFilesystem::doVFS(const std::string& name, Handle<Value> argv[], int a
 }
 
 int
-CodiusNodeFilesystem::open(const char* name, int flags)
+CodiusNodeFilesystem::open(const char* name, int flags, int mode)
 {
   Handle<Value> argv[] = {
     String::New (name),
     Int32::New (flags),
-    Int32::New (0) //FIXME: We also need the mode?
+    Int32::New (mode)
   };
 
   VFSResult ret = doVFS(std::string ("open"), argv, 3);

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -94,7 +94,27 @@ CodiusNodeFilesystem::close(int fd)
 int
 CodiusNodeFilesystem::fstat(int fd, struct stat* buf)
 {
-  return -ENOSYS;
+  Handle<Value> argv[] = {
+    Int32::New (fd)
+  };
+  VFSResult ret = doVFS (std::string ("fstat"), argv, 1);
+
+  if (ret.errnum) 
+    return -ret.errnum;
+
+  Handle<Object> statObj = ret.result->ToObject();
+  buf->st_dev = statObj->Get(String::NewSymbol("dev"))->ToInt32()->Value();
+  buf->st_ino = statObj->Get(String::NewSymbol("ino"))->ToInt32()->Value();
+  buf->st_mode = statObj->Get(String::NewSymbol("mode"))->ToInt32()->Value();
+  buf->st_nlink = statObj->Get(String::NewSymbol("nlink"))->ToInt32()->Value();
+  buf->st_uid = statObj->Get(String::NewSymbol("uid"))->ToInt32()->Value();
+  buf->st_gid = statObj->Get(String::NewSymbol("gid"))->ToInt32()->Value();
+  buf->st_rdev = statObj->Get(String::NewSymbol("rdev"))->ToInt32()->Value();
+  buf->st_size = statObj->Get(String::NewSymbol("size"))->ToInt32()->Value();
+  buf->st_blksize = statObj->Get(String::NewSymbol("blksize"))->ToInt32()->Value();
+  buf->st_blocks = statObj->Get(String::NewSymbol("blocks"))->ToInt32()->Value();
+
+  return 0;
 }
 
 off_t
@@ -160,4 +180,58 @@ CodiusNodeFilesystem::access (const char* name, int mode)
     return -ret.errnum;
 
   return ret.result->ToInt32()->Value();
+}
+
+int
+CodiusNodeFilesystem::stat (const char* name, struct stat* buf)
+{
+  Handle<Value> argv[] = {
+    String::New (name)
+  };
+
+  VFSResult ret = doVFS (std::string ("stat"), argv, 1);
+
+  if (ret.errnum) 
+    return -ret.errnum;
+
+  Handle<Object> statObj = ret.result->ToObject();
+  buf->st_dev = statObj->Get(String::NewSymbol("dev"))->ToInt32()->Value();
+  buf->st_ino = statObj->Get(String::NewSymbol("ino"))->ToInt32()->Value();
+  buf->st_mode = statObj->Get(String::NewSymbol("mode"))->ToInt32()->Value();
+  buf->st_nlink = statObj->Get(String::NewSymbol("nlink"))->ToInt32()->Value();
+  buf->st_uid = statObj->Get(String::NewSymbol("uid"))->ToInt32()->Value();
+  buf->st_gid = statObj->Get(String::NewSymbol("gid"))->ToInt32()->Value();
+  buf->st_rdev = statObj->Get(String::NewSymbol("rdev"))->ToInt32()->Value();
+  buf->st_size = statObj->Get(String::NewSymbol("size"))->ToInt32()->Value();
+  buf->st_blksize = statObj->Get(String::NewSymbol("blksize"))->ToInt32()->Value();
+  buf->st_blocks = statObj->Get(String::NewSymbol("blocks"))->ToInt32()->Value();
+
+  return 0;
+}
+
+int
+CodiusNodeFilesystem::lstat (const char* name, struct stat* buf)
+{
+  Handle<Value> argv[] = {
+    String::New (name)
+  };
+
+  VFSResult ret = doVFS (std::string ("lstat"), argv, 1);
+
+  if (ret.errnum) 
+    return -ret.errnum;
+
+  Handle<Object> statObj = ret.result->ToObject();
+  buf->st_dev = statObj->Get(String::NewSymbol("dev"))->ToInt32()->Value();
+  buf->st_ino = statObj->Get(String::NewSymbol("ino"))->ToInt32()->Value();
+  buf->st_mode = statObj->Get(String::NewSymbol("mode"))->ToInt32()->Value();
+  buf->st_nlink = statObj->Get(String::NewSymbol("nlink"))->ToInt32()->Value();
+  buf->st_uid = statObj->Get(String::NewSymbol("uid"))->ToInt32()->Value();
+  buf->st_gid = statObj->Get(String::NewSymbol("gid"))->ToInt32()->Value();
+  buf->st_rdev = statObj->Get(String::NewSymbol("rdev"))->ToInt32()->Value();
+  buf->st_size = statObj->Get(String::NewSymbol("size"))->ToInt32()->Value();
+  buf->st_blksize = statObj->Get(String::NewSymbol("blksize"))->ToInt32()->Value();
+  buf->st_blocks = statObj->Get(String::NewSymbol("blocks"))->ToInt32()->Value();
+
+  return 0;
 }

--- a/src/node-filesystem.cpp
+++ b/src/node-filesystem.cpp
@@ -120,13 +120,12 @@ CodiusNodeFilesystem::getdents(int fd, struct linux_dirent* dirs, unsigned int c
   Handle<Array> fileList = Handle<Array>::Cast (ret.result);
   for (uint32_t i = 0; i < fileList->Length(); i++) {
     Handle<String> filename = fileList->Get(i)->ToString();
-    char buf[filename->Utf8Length()];
-    filename->WriteUtf8 (buf, filename->Utf8Length());
-    builder.append (std::string (buf));
+    std::vector<char> buf (filename->Utf8Length()+1);
+    filename->WriteUtf8 (buf.data(), buf.size());
+    builder.append (std::string (buf.data()));
   }
   std::vector<char> buf;
   buf = builder.data();
   memcpy (dirs, buf.data(), buf.size());
   return buf.size();
 }
-

--- a/src/sandbox-node-module.cpp
+++ b/src/sandbox-node-module.cpp
@@ -350,7 +350,7 @@ NodeSandbox::node_spawn(const Arguments& args)
     }
   }
 
-  wrap->sbox->getVFS().setCWD ("/");
+  wrap->sbox->getVFS().setCWD ("/contract/");
   wrap->sbox->spawn(argv, envp);
 
   goto out;

--- a/src/sandbox-node-module.cpp
+++ b/src/sandbox-node-module.cpp
@@ -222,7 +222,7 @@ NodeSandbox::launchDebugger() {
 void
 NodeSandbox::handleSignal(int signal)
 {
-  if (m_debuggerOnCrash && signal == SIGSEGV || signal == SIGABRT) {
+  if (m_debuggerOnCrash && (signal == SIGSEGV || signal == SIGABRT || signal == SIGTRAP)) {
     launchDebugger();
   }
   std::vector<Handle<Value> > args = {

--- a/src/sandbox-node-module.cpp
+++ b/src/sandbox-node-module.cpp
@@ -1,5 +1,6 @@
 #include "sandbox.h"
 #include "sandbox-ipc.h"
+#include "node-sandbox.h"
 
 #include <node.h>
 #include <vector>
@@ -48,179 +49,168 @@ NodeIPC::onReadReady()
   node::MakeCallback (nodeThis, "onData", 2, argv);
 }
 
-class SandboxWrapper : public node::ObjectWrap {
-  public:
-    SandboxWrapper();
-    ~SandboxWrapper();
-    std::unique_ptr<NodeSandbox> sbox;
-    Persistent<Object> nodeThis;
-    friend class NodeSandbox;
+NodeSandbox::NodeSandbox(SandboxWrapper* _wrap)
+  : wrap(_wrap),
+    m_debuggerOnCrash(false)
+{
+  getVFS().mountFilesystem (std::string("/"), std::shared_ptr<Filesystem>(new CodiusNodeFilesystem (this)));
+}
+
+std::vector<char>
+NodeSandbox::mapFilename(std::vector<char> fname)
+{
+  Handle<Value> argv[1] = {
+    String::NewSymbol (fname.data())
+  };
+  Handle<Value> callbackRet = node::MakeCallback (wrap->nodeThis, "mapFilename", 1, argv);
+  if (callbackRet->IsString()) {
+    std::vector<char> buf;
+    buf.resize (callbackRet->ToString()->Utf8Length()+1);
+    callbackRet->ToString()->WriteUtf8 (buf.data());
+    buf[buf.size()-1] = 0;
+    return buf;
+  } else {
+    ThrowException(Exception::TypeError(String::New("Expected a string return value")));
+  }
+  return std::vector<char>();
+}
+
+void
+NodeSandbox::emitEvent(const std::string& name, std::vector<Handle<Value> >& argv)
+{
+  std::vector<Handle<Value> >  args;
+  args.push_back (String::NewSymbol (name.c_str()));
+  args.insert (args.end(), argv.begin(), argv.end());
+  node::MakeCallback (wrap->nodeThis, "emit", args.size(), args.data());
+}
+
+Sandbox::SyscallCall
+NodeSandbox::mapFilename(const SyscallCall& call)
+{
+  SyscallCall ret (call);
+  std::vector<char> fname (1024);
+  copyString (call.args[0], fname.size(), fname.data());
+  fname = mapFilename (fname);
+  if (fname.size()) {
+    ret.args[0] = writeScratch (fname.size(), fname.data());
+  } else {
+    ret.id = -1;
+  }
+  return ret;
+}
+
+Sandbox::SyscallCall
+NodeSandbox::handleSyscall(const SyscallCall &call)
+{
+  SyscallCall ret (call);
+
+  if (ret.id == __NR_getsockname) {
+    //FIXME: Should return what was originally passed in via bind() or
+    //similar
+  } else if (ret.id == __NR_getsockopt) {
+    //FIXME: Needs emulation
+  } else if (ret.id == __NR_setsockopt) {
+    //FIXME: Needs emulation
+  } else if (ret.id == __NR_bind) {
+    struct sockaddr_un addr;
+    addr.sun_family = AF_UNIX;
+    snprintf (addr.sun_path, sizeof (addr.sun_path), "/tmp/codius-sandbox-socket-%d-%d", getChildPID(), static_cast<int>(ret.args[0]));
+    ret.args[1] = writeScratch (sizeof (addr), reinterpret_cast<char*>(&addr));
+    ret.args[2] = sizeof (addr);
+    std::vector<Handle<Value> > args = {
+      String::New (addr.sun_path)
+    };
+    emitEvent ("newSocket", args);
+  } else if (ret.id == __NR_socket) {
+    ret.args[0] = AF_UNIX;
+  } else if (ret.id == __NR_execve) {
+    kill();
+  } else {
+    //std::cout << "try " << call.id << std::endl;
+  }
+  return ret;
 };
 
-class NodeSandbox : public Sandbox {
-  public:
-    NodeSandbox(SandboxWrapper* _wrap)
-      : wrap(_wrap),
-        m_debuggerOnCrash(false)
-    {}
+static Handle<Value> fromJsonNode(JsonNode* node) {
+  char* buf;
+  Handle<Context> context = Context::GetCurrent();
+  Handle<Object> global = context->Global();
+  Handle<Object> JSON = global->Get(String::New ("JSON"))->ToObject();
+  Handle<Function> JSON_parse = Handle<Function>::Cast(JSON->Get(String::New("parse")));
 
-    std::vector<char> mapFilename(std::vector<char> fname)
-    {
-      Handle<Value> argv[1] = {
-        String::NewSymbol (fname.data())
-      };
-      Handle<Value> callbackRet = node::MakeCallback (wrap->nodeThis, "mapFilename", 1, argv);
-      if (callbackRet->IsString()) {
-        std::vector<char> buf;
-        buf.resize (callbackRet->ToString()->Utf8Length()+1);
-        callbackRet->ToString()->WriteUtf8 (buf.data());
-        buf[buf.size()-1] = 0;
-        return buf;
-      } else {
-        ThrowException(Exception::TypeError(String::New("Expected a string return value")));
-      }
-      return std::vector<char>();
-    }
+  buf = json_encode (node);
+  Handle<Value> argv[1] = {
+    String::New (buf)
+  };
+  Handle<Value> parsedObj = JSON_parse->Call(JSON, 1, argv);
+  free (buf);
 
-    void emitEvent(const std::string& name, std::vector<Handle<Value> >& argv) {
-      std::vector<Handle<Value> >  args;
-      args.push_back (String::NewSymbol (name.c_str()));
-      args.insert (args.end(), argv.begin(), argv.end());
-      node::MakeCallback (wrap->nodeThis, "emit", args.size(), args.data());
-    }
+  return parsedObj;
+}
 
-    SyscallCall mapFilename(const SyscallCall& call) {
-      SyscallCall ret (call);
-      std::vector<char> fname (1024);
-      copyString (call.args[0], fname.size(), fname.data());
-      fname = mapFilename (fname);
-      if (fname.size()) {
-        ret.args[0] = writeScratch (fname.size(), fname.data());
-      } else {
-        ret.id = -1;
-      }
-      return ret;
-    }
+static JsonNode* toJsonNode(Handle<Value> object) {
+  std::vector<char> buf;
+  Handle<Context> context = Context::GetCurrent();
+  Handle<Object> global = context->Global();
+  Handle<Object> JSON = global->Get(String::New ("JSON"))->ToObject();
+  Handle<Function> JSON_stringify = Handle<Function>::Cast(JSON->Get(String::New("stringify")));
+  Handle<Value> argv[1] = {
+    object
+  };
+  Handle<String> ret = JSON_stringify->Call(JSON, 1, argv)->ToString();
 
-    SyscallCall handleSyscall(const SyscallCall &call) override {
-      SyscallCall ret (call);
+  buf.resize (ret->Utf8Length());
+  ret->WriteUtf8 (buf.data());
+  return json_decode (buf.data());
+}
 
-      if (ret.id == __NR_open || ret.id == __NR_stat || ret.id == __NR_access || ret.id == __NR_readlink || ret.id == __NR_lstat) {
-        ret = mapFilename (ret);
-      } else if (ret.id == __NR_getsockname) {
-        //FIXME: Should return what was originally passed in via bind() or
-        //similar
-      } else if (ret.id == __NR_getsockopt) {
-        //FIXME: Needs emulation
-      } else if (ret.id == __NR_setsockopt) {
-        //FIXME: Needs emulation
-      } else if (ret.id == __NR_bind) {
-        struct sockaddr_un addr;
-        addr.sun_family = AF_UNIX;
-        snprintf (addr.sun_path, sizeof (addr.sun_path), "/tmp/codius-sandbox-socket-%d-%d", getChildPID(), static_cast<int>(ret.args[0]));
-        ret.args[1] = writeScratch (sizeof (addr), reinterpret_cast<char*>(&addr));
-        ret.args[2] = sizeof (addr);
-        std::vector<Handle<Value> > args = {
-          String::New (addr.sun_path)
-        };
-        emitEvent ("newSocket", args);
-      } else if (ret.id == __NR_socket) {
-        ret.args[0] = AF_UNIX;
-      } else if (ret.id == __NR_execve) {
-        kill();
-      } else {
-        //std::cout << "try " << call.id << std::endl;
-      }
-      return ret;
-    };
+void
+NodeSandbox::handleIPC(codius_request_t* request)
+{
+  Handle<Value> requestArgs = fromJsonNode (request->data);
+  Handle<Value> argv[4] = {
+    String::New(request->api_name),
+    String::New(request->method_name),
+    requestArgs,
+    External::Wrap(request)
+  };
+  node::MakeCallback (wrap->nodeThis, "onIPC", 4, argv)->ToObject();
+};
 
-    static Handle<Value> fromJsonNode(JsonNode* node) {
-      char* buf;
-      Handle<Context> context = Context::GetCurrent();
-      Handle<Object> global = context->Global();
-      Handle<Object> JSON = global->Get(String::New ("JSON"))->ToObject();
-      Handle<Function> JSON_parse = Handle<Function>::Cast(JSON->Get(String::New("parse")));
+void
+NodeSandbox::handleExit(int status)
+{
+  std::vector<Handle<Value> > args = {
+    Int32::New (status)
+  };
+  emitEvent ("exit", args);
+}
 
-      buf = json_encode (node);
-      Handle<Value> argv[1] = {
-        String::New (buf)
-      };
-      Handle<Value> parsedObj = JSON_parse->Call(JSON, 1, argv);
-      free (buf);
+void
+NodeSandbox::launchDebugger() {
+  releaseChild (SIGSTOP);
+  char pidStr[15];
+  snprintf (pidStr, sizeof (pidStr), "%d", getChildPID());
+  // libuv apparently sets O_CLOEXEC, just to frustrate us if we want to
+  // break out
+  fcntl (0, F_SETFD, 0);
+  fcntl (1, F_SETFD, 0);
+  fcntl (2, F_SETFD, 0);
+  if (execlp ("gdb", "gdb", "-p", pidStr, NULL) < 0) {
+    error (EXIT_FAILURE, errno, "Could not start debugger");
+  }
+}
 
-      return parsedObj;
-    }
-
-    static JsonNode* toJsonNode(Handle<Value> object) {
-      std::vector<char> buf;
-      Handle<Context> context = Context::GetCurrent();
-      Handle<Object> global = context->Global();
-      Handle<Object> JSON = global->Get(String::New ("JSON"))->ToObject();
-      Handle<Function> JSON_stringify = Handle<Function>::Cast(JSON->Get(String::New("stringify")));
-      Handle<Value> argv[1] = {
-        object
-      };
-      Handle<String> ret = JSON_stringify->Call(JSON, 1, argv)->ToString();
-
-      buf.resize (ret->Utf8Length());
-      ret->WriteUtf8 (buf.data());
-      return json_decode (buf.data());
-    }
-
-    void handleIPC(codius_request_t* request) override {
-      Handle<Value> requestArgs = fromJsonNode (request->data);
-      Handle<Value> argv[4] = {
-        String::New(request->api_name),
-        String::New(request->method_name),
-        requestArgs,
-        External::Wrap(request)
-      };
-      node::MakeCallback (wrap->nodeThis, "onIPC", 4, argv)->ToObject();
-    };
-
-    void handleExit(int status) override {
-      std::vector<Handle<Value> > args = {
-        Int32::New (status)
-      };
-      emitEvent ("exit", args);
-    }
-
-    void launchDebugger() {
-      releaseChild (SIGSTOP);
-      char pidStr[15];
-      snprintf (pidStr, sizeof (pidStr), "%d", getChildPID());
-      // libuv apparently sets O_CLOEXEC, just to frustrate us if we want to
-      // break out
-      fcntl (0, F_SETFD, 0);
-      fcntl (1, F_SETFD, 0);
-      fcntl (2, F_SETFD, 0);
-      if (execlp ("gdb", "gdb", "-p", pidStr, NULL) < 0) {
-        error (EXIT_FAILURE, errno, "Could not start debugger");
-      }
-    }
-
-    void handleSignal(int signal) override {
-      if (m_debuggerOnCrash && signal == SIGSEGV) {
-        launchDebugger();
-      }
-      std::vector<Handle<Value> > args = {
-        Int32::New(signal)
-      };
-      emitEvent ("signal", args);
-    };
-
-    static void Init(Handle<Object> exports);
-    SandboxWrapper* wrap;
-
-  private:
-      bool m_debuggerOnCrash;
-      static Handle<Value> node_spawn(const Arguments& args);
-      static Handle<Value> node_kill(const Arguments& args);
-      static Handle<Value> node_finish_ipc(const Arguments& args);
-      static Handle<Value> node_new(const Arguments& args);
-      static Handle<Value> node_getDebugOnCrash(Local<String> property, const AccessorInfo& info);
-      static void node_setDebugOnCrash(Local<String> property, Local<Value> value, const AccessorInfo& info);
-      static Persistent<Function> s_constructor;
+void
+NodeSandbox::handleSignal(int signal)
+{
+  if (m_debuggerOnCrash && signal == SIGSEGV || signal == SIGABRT) {
+    launchDebugger();
+  }
+  std::vector<Handle<Value> > args = {
+    Int32::New(signal)
+  };
+  emitEvent ("signal", args);
 };
 
 Persistent<Function> NodeSandbox::s_constructor;

--- a/src/sandbox-node-module.cpp
+++ b/src/sandbox-node-module.cpp
@@ -129,7 +129,7 @@ class NodeSandbox : public Sandbox {
       } else if (ret.id == __NR_execve) {
         kill();
       } else {
-        std::cout << "try " << call.id << std::endl;
+        std::cout << "try " << call.id << "(" << call.args[0] << ", " << call.args[1] << ")" << std::endl;
       }
       return ret;
     };

--- a/src/sandbox-node-module.cpp
+++ b/src/sandbox-node-module.cpp
@@ -128,7 +128,6 @@ NodeSandbox::handleSyscall(const SyscallCall &call)
   } else if (ret.id == __NR_execve) {
     kill();
   } else {
-    //std::cout << "try " << call.id << std::endl;
   }
   return ret;
 };
@@ -351,6 +350,7 @@ NodeSandbox::node_spawn(const Arguments& args)
     }
   }
 
+  wrap->sbox->getVFS().setCWD ("/");
   wrap->sbox->spawn(argv, envp);
 
   goto out;

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -180,6 +180,8 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (openat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (fstat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (lseek), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (write), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (access), 0);
 
   // This needs its arguments sanitized
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (fcntl), 0);
@@ -215,7 +217,6 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   // * Can't cause any harm outside the sandbox
   // * Require some file descriptor from a previously-sanitized call to i.e.
   // open()
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (write), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (poll), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mmap), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mprotect), 0);
@@ -225,7 +226,6 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (rt_sigprocmask), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (readv), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (writev), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (access), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (select), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (sched_yield), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (getpid), 0);

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -513,3 +513,9 @@ Sandbox::traceChild()
 
   ptrace (PTRACE_CONT, priv->pid, 0, 0);
 }
+
+VFS&
+Sandbox::getVFS() const
+{
+  return *m_p->vfs;
+}

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -168,6 +168,8 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (openat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (stat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (lstat), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getcwd), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (readlink), 0);
 
 #define VFS_FILTER(x) seccomp_rule_add (ctx, \
                                         SCMP_ACT_TRACE (0), \
@@ -205,7 +207,6 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
 
   // These need their return values faked in some way
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (uname), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getcwd), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getrlimit), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getuid), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getgid), 0);

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -170,15 +170,16 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (chdir), 0);
 
   // These interact with the VFS layer
+  // TODO: They should have BPF conditions added to check if the FD is above
+  // VFS::firstVirtualFD
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (open), 0);
-  // (read/close/etc should have some seccomp filter that permits non-negative FDs to be
-  // passed through)
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (read), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (close), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (stat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (ioctl), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (openat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (fstat), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (lseek), 0);
 
   // This needs its arguments sanitized
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (fcntl), 0);
@@ -214,12 +215,8 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   // * Can't cause any harm outside the sandbox
   // * Require some file descriptor from a previously-sanitized call to i.e.
   // open()
-  //seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (read), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (write), 0);
-  //seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (close), 0);
-  //seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (fstat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (poll), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (lseek), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mmap), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mprotect), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (munmap), 0);

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -167,6 +167,7 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (access), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (openat), 0);
   seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (stat), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (lstat), 0);
 
 #define VFS_FILTER(x) seccomp_rule_add (ctx, \
                                         SCMP_ACT_TRACE (0), \

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -156,48 +156,96 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   
   prctl (PR_SET_NO_NEW_PRIVS, 1);
 
-  ctx = seccomp_init (SCMP_ACT_TRACE (0));
+  ctx = seccomp_init (SCMP_ACT_KILL);
 
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (write), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_KILL, SCMP_SYS (ptrace), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (execve), 0);
+
+  // Used to track chdir calls
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (chdir), 0);
+
+  // These interact with the VFS layer
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (open), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (stat), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (ioctl), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (openat), 0);
+
+  // This needs its arguments sanitized
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (fcntl), 0);
+
+  // These are traced to implement socket remapping
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (socket), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (connect), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (bind), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (setsockopt), 0);
+
+  // These need their return values faked in some way
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getsockname), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getpeername), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getsockopt), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (uname), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getdents), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getcwd), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getrlimit), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getuid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getgid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (geteuid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getegid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getppid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getpgrp), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getgroups), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getresuid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getresgid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (capget), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (gettid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_TRACE (0), SCMP_SYS (getdents64), 0);
+
+  // All of these are allowed because they either:
+  // * Can't cause any harm outside the sandbox
+  // * Require some file descriptor from a previously-sanitized call to i.e.
+  // open()
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (read), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (write), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (close), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (fstat), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (listen), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (accept4), 0);
-
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (writev), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (readv), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (sched_yield), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (clone), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mprotect), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (poll), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (lseek), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mmap), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (brk), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mprotect), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (munmap), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (gettid), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (clock_getres), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (rt_sigprocmask), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (brk), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (rt_sigaction), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (ioctl), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (eventfd2), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (pipe2), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_create1), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (futex), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (rt_sigprocmask), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (readv), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (writev), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (access), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (select), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (sched_yield), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (getpid), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (accept), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (listen), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (exit), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (gettimeofday), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (tkill), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_create), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (restart_syscall), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (clock_gettime), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (clock_getres), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (clock_nanosleep), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (exit_group), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_wait), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_ctl), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (getcwd), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (tgkill), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (pselect6), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (ppoll), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (arch_prctl), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (set_robust_list), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (get_robust_list), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (set_tid_address), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (arch_prctl), 0); // FIXME: what is this used for?
-  seccomp_rule_add (ctx, SCMP_ACT_KILL, SCMP_SYS (ptrace), 0);
-
-  // FIXME: Do these need emulated?
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (uname), 0);
-  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (getrlimit), 0);
-
-  //seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (getsockname), 0);
-  //seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (getsockopt), 0);
-  //seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (fstat), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_pwait), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (accept4), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (eventfd2), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_create1), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (pipe2), 0);
 
   if (0<seccomp_load (ctx))
     error(EXIT_FAILURE, errno, "Could not lock down sandbox");

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -349,6 +349,7 @@ SandboxPrivate::handleSeccompEvent()
   regs.esi = call.args[3];
   regs.edi = call.args[4];
   regs.ebp = call.args[5];
+  regs.eax = call.returnVal;
 #else
   regs.orig_rax = call.id;
   regs.rdi = call.args[0];
@@ -357,6 +358,7 @@ SandboxPrivate::handleSeccompEvent()
   regs.rcx = call.args[3];
   regs.r8 = call.args[4];
   regs.r9 = call.args[5];
+  regs.rax = call.returnVal;
 #endif
 
   if (ptrace (PTRACE_SETREGS, pid, 0, &regs) < 0) {

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -262,6 +262,7 @@ Sandbox::execChild(char** argv, std::map<std::string, std::string>& envp)
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (epoll_create1), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (pipe2), 0);
   seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (futex), 0);
+  seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (set_tid_address), 0);
 
   if (0<seccomp_load (ctx))
     error(EXIT_FAILURE, errno, "Could not lock down sandbox");

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -1,5 +1,4 @@
 #include "sandbox.h"
-#include <dirent.h>
 
 #include <iostream>
 #include <errno.h>
@@ -19,75 +18,10 @@
 #include <uv.h>
 #include <memory>
 #include <cassert>
+#include "vfs.h"
 
 #include "codius-util.h"
 #include "sandbox-ipc.h"
-
-struct linux_dirent {
-  unsigned long d_ino;
-  unsigned long d_off;
-  unsigned short d_reclen;
-  char d_name[];
-  /*
-  char pad
-  char d_type;
-  */
-};
-
-class DirentBuilder {
-public:
-  void append(const std::string& name) {
-    m_names.push_back (name);
-  }
-
-  std::vector<char> data() const {
-    std::vector<char> ret;
-    for (auto i = m_names.cbegin(); i != m_names.cend(); i++) {
-      push (ret, *i);
-    }
-    return ret;
-  }
-
-private:
-  std::vector<std::string> m_names;
-
-  void push(std::vector<char>& ret, const std::string& name) const {
-    static long inode = 4242;
-    unsigned short reclen;
-    char* d_type;
-
-    reclen = sizeof (linux_dirent) + name.size() + sizeof (char) * 3;
-    off_t start = ret.size();
-    ret.resize (start + reclen);
-    linux_dirent* ent = reinterpret_cast<linux_dirent*>(&ret.data()[start]);
-    ent->d_ino = inode++;
-    ent->d_reclen = reclen;
-    memcpy (ent->d_name, name.data(), name.size() + 1);
-    d_type = reinterpret_cast<char*>(ent + reclen - 1);
-    *d_type = DT_REG;
-  }
-};
-
-void
-dirent_append (const char* filename, linux_dirent** ent)
-{
-  unsigned short reclen;
-  char* d_type;
-  linux_dirent* ret;
-
-  reclen = sizeof (linux_dirent) + strlen (filename) + sizeof (char) * 3;
-
-  ret = static_cast<linux_dirent*>(malloc (sizeof (linux_dirent) + strlen (filename) + sizeof (char)*2));
-  memset (ret, 0, reclen);
-  ret->d_ino = 4242;
-  ret->d_reclen = reclen;
-  memcpy (ret->d_name, filename, strlen (filename) + 1);
-
-  d_type = reinterpret_cast<char*>(ret + reclen - 1);
-  *d_type = DT_REG;
-
-  *ent = ret;
-}
 
 #define PTRACE_EVENT_SECCOMP 7
 
@@ -99,7 +33,8 @@ class SandboxPrivate {
       : d (d),
         pid(0),
         entered_main(false),
-        scratchAddr(0) {}
+        scratchAddr(0),
+        vfs(new VFS(d)) {}
     Sandbox* d;
     std::vector<std::unique_ptr<SandboxIPC> > ipcSockets;
     pid_t pid;
@@ -109,80 +44,10 @@ class SandboxPrivate {
     Sandbox::Address nextScratchSegment;
     void handleSeccompEvent();
     void handleExecEvent();
-    Sandbox::SyscallCall handleVFSCall(const Sandbox::SyscallCall& call);
     std::string cwd;
     std::vector<int> openFiles;
+    std::unique_ptr<VFS> vfs;
 };
-
-Sandbox::SyscallCall
-SandboxPrivate::handleVFSCall(const Sandbox::SyscallCall& call)
-{
-  Sandbox::SyscallCall ret(call);
-  if (call.id == __NR_open) {
-    std::vector<char> buf (1024);
-    d->copyString (call.args[0], buf.size(), buf.data());
-    std::cout << "attempt " << buf.data() << std::endl;
-    if (strncmp (buf.data(), "/usr/lib", strlen("/usr/lib")) != 0 && strncmp (buf.data(), "/lib", strlen("/lib") != 0)) {
-      ret.id = -1;
-      int fh = open (buf.data(), call.args[1]);
-      if (fh > -1) {
-        openFiles.push_back (fh);
-        fh += 4095;
-        ret.returnVal = fh;
-      } else {
-        ret.returnVal = fh;
-      }
-      std::cout << "open " << buf.data() << " = " << fh << std::endl;
-    }
-  } else if (call.id == __NR_close) {
-    int fh = call.args[0]-4095;
-    if (fh >= 4095) {
-      ret.id = -1;
-      ret.returnVal = close (fh);
-      std::cout << "close " << fh << std::endl;
-    }
-  } else if (call.id == __NR_read) {
-    int fh = call.args[0] - 4095;
-    if (fh >= 4095) {
-      ret.id = -1;
-      std::vector<char> buf (call.args[2]);
-      ssize_t readCount = read (fh, buf.data(), buf.size());
-      d->writeData (call.args[1], buf.size(), buf.data());
-      ret.returnVal = readCount;
-      std::cout << "read " << fh << " = " << readCount << std::endl;
-      std::cout << std::hex;
-      for (unsigned int i = 0;i < buf.size(); i++) {
-        std::cout << (Sandbox::Word) buf[i] << " ";
-      }
-      std::cout << std::endl;
-    }
-  } else if (call.id == __NR_fstat) {
-    int fh = call.args[0] - 4095;
-    if (fh >= 4095) {
-      ret.id = -1;
-      struct stat sbuf;
-      ret.returnVal = fstat (fh, &sbuf);
-      d->writeData(call.args[1], sizeof (sbuf), (char*)&sbuf);
-    }
-  } else if (call.id == __NR_getdents) {
-    static bool read = false;
-    ret.id = -1;
-    std::cout << "call getdents" << std::endl;
-    if (!read) {
-      std::vector<char> buf;
-      DirentBuilder builder;
-      builder.append ("hello");
-      builder.append ("codius");
-      buf = builder.data();
-      d->writeData(call.args[1], buf.size(), buf.data());
-      ret.returnVal = buf.size();
-      read = true;
-    } else {
-      ret.returnVal = 0;
-    }
-  }
-  return ret;
-}
 
 std::string
 Sandbox::getCWD() const
@@ -485,7 +350,7 @@ SandboxPrivate::handleSeccompEvent()
     d->copyString (call.args[0], newDir.size(), newDir.data());
     cwd = newDir.data();
   } else {
-    call = handleVFSCall (call);
+    call = vfs->handleSyscall (call);
   }
 
 #ifdef __i386__

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -419,7 +419,7 @@ bool
 Sandbox::writeData (Address addr, size_t length, const char* buf)
 {
   for (size_t i = 0; i < length; i++) {
-    pokeData (m_p->scratchAddr + i, buf[i]);
+    pokeData (addr + i, buf[i]);
   }
   if (errno)
     return false;

--- a/src/sandbox.cpp
+++ b/src/sandbox.cpp
@@ -299,12 +299,12 @@ Sandbox::copyData(Address addr, size_t length, void* buf)
 }
 
 bool
-Sandbox::copyString (Address addr, int maxLength, char* buf)
+Sandbox::copyString (Address addr, size_t maxLength, char* buf)
 {
   //FIXME: This causes a lot of redundant copying. Whole words are moved around
   //and then only a single byte is taken out of it when we could be operating on
   //bigger chunks of data.
-  for (int i = 0; i < maxLength; i++) {
+  for (size_t i = 0; i < maxLength; i++) {
     buf[i] = peekData(addr + i);
     if (buf[i] == 0)
       break;

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -60,10 +60,13 @@ File::close()
 std::pair<std::string, std::shared_ptr<Filesystem> >
 VFS::getFilesystem(const std::string& path) const
 {
+  std::string searchPath (path);
   std::string longest_mount;
+  if (path[0] == '.')
+    searchPath = m_cwd->path() + path;
   for(auto i = m_mountpoints.cbegin(); i != m_mountpoints.cend(); i++) {
-    if (path.compare(0, i->first.size(), i->first) == 0) {
-      std::string newPath (path.substr (i->first.size()));
+    if (searchPath.compare(0, i->first.size(), i->first) == 0) {
+      std::string newPath (searchPath.substr (i->first.size()-1));
       return std::make_pair (newPath, i->second);
     }
   }

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -22,6 +22,10 @@ VFS::VFS(Sandbox* sandbox)
   m_whitelist.push_back ("/lib64/tls/libc.so.6");
   m_whitelist.push_back ("/lib64/x86_64/libc.so.6");
   m_whitelist.push_back ("/lib64/libc.so.6");
+  m_whitelist.push_back ("/lib64/libstdc++.so.6");
+  m_whitelist.push_back ("/lib64/libm.so.6");
+  m_whitelist.push_back ("/lib64/libgcc_s.so.1");
+  m_whitelist.push_back ("/lib64/libpthread.so.0");
   m_whitelist.push_back ("/etc/ld.so.cache");
 }
 

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -239,10 +239,10 @@ VFS::do_getdents (Sandbox::SyscallCall& call)
     File::Ptr file = getFile (call.args[0]);
     call.id = -1;
     if (file) {
-      void* buf = malloc (call.args[2]);
-      call.returnVal = file->getdents ((struct linux_dirent*)buf, call.args[2]);
-      m_sbox->writeData(call.args[1], call.args[2], (char*)buf);
-      free (buf);
+      std::vector<char> buf (call.args[2]);
+      struct linux_dirent* dirents = (struct linux_dirent*)buf.data();
+      call.returnVal = file->getdents (dirents, buf.size());
+      m_sbox->writeData(call.args[1], call.returnVal, buf.data());
     } else {
       call.returnVal = -EBADF;
     }

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -101,7 +101,7 @@ VFS::do_readlink (Sandbox::SyscallCall& call)
     if (fs.second) {
       std::vector<char> buf (call.args[2]);
       call.returnVal = fs.second->readlink (fs.first.c_str(), buf.data(), buf.size());
-      m_sbox->writeData (call.pid, call.args[1], std::min(buf.size(), call.returnVal), buf.data());
+      m_sbox->writeData (call.args[1], std::min(buf.size(), call.returnVal), buf.data());
     } else {
       call.returnVal = -ENOENT;
     }

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -1,16 +1,17 @@
 #include "vfs.h"
 #include <dirent.h>
 #include <memory.h>
-#include <sys/syscall.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <iostream>
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <cassert>
 #include <error.h>
+#include <fcntl.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <asm-generic/posix_types.h>
 #include "dirent-builder.h"
 
@@ -376,61 +377,3 @@ VFS::isWhitelisted(const std::string& str)
   return false;
 }
 
-int
-NativeFilesystem::open(const char* name, int flags)
-{
-  std::string newName (name);
-  newName = m_root + "/" + newName;
-  return ::open (newName.c_str(), flags);
-}
-
-int
-NativeFilesystem::close(int fd)
-{
-  return ::close (fd);
-}
-
-ssize_t
-NativeFilesystem::read(int fd, void* buf, size_t count)
-{
-  return ::read (fd, buf, count);
-}
-
-int
-NativeFilesystem::fstat(int fd, struct stat* buf)
-{
-  return ::fstat (fd, buf);
-}
-
-int
-NativeFilesystem::getdents(int fd, struct linux_dirent* dirs, unsigned int count)
-{
-  return ::syscall (SYS_getdents, fd, dirs, count);
-}
-
-off_t
-NativeFilesystem::lseek(int fd, off_t offset, int whence)
-{
-  return ::lseek (fd, offset, whence);
-}
-
-NativeFilesystem::NativeFilesystem(const std::string& root)
-  : Filesystem()
-  , m_root (root)
-{
-}
-
-ssize_t
-NativeFilesystem::write(int fd, void* buf, size_t count)
-{
-  return ::write (fd, buf, count);
-}
-
-int
-NativeFilesystem::access(const char* name, int mode)
-{
-  return ::access (name, mode);
-}
-
-Filesystem::Filesystem()
-{}

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -22,7 +22,6 @@ VFS::VFS(Sandbox* sandbox)
   m_whitelist.push_back ("/lib64/x86_64/libc.so.6");
   m_whitelist.push_back ("/lib64/libc.so.6");
   m_whitelist.push_back ("/etc/ld.so.cache");
-  //mountFilesystem (std::string("/codius"), std::shared_ptr<Filesystem>(new NativeFilesystem ("/tmp/sbox-root")));
 }
 
 void
@@ -98,10 +97,11 @@ VFS::do_openat (Sandbox::SyscallCall& call)
         call.returnVal = -ENOENT;
       }
     }
-  } else {
-    //FIXME: fd should be verified to make sure one can't do dup2(AT_FDCWD, foo)
-    //FIXME: Should also use map of opened filenames to figure out what
-    //filesystem we end up on
+    fname = fdPath + fname;
+  }
+
+  //FIXME: This is copied from do_open. Needs put in a common method
+  if (!isWhitelisted (fname)) {
     call.id = -1;
     std::pair<std::string, std::shared_ptr<Filesystem> > fs = getFilesystem (fname);
     if (fs.second) {

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -1,0 +1,149 @@
+#include "vfs.h"
+#include <dirent.h>
+#include <memory.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <iostream>
+#include <stdio.h>
+
+struct linux_dirent {
+  unsigned long d_ino;
+  unsigned long d_off;
+  unsigned short d_reclen;
+  char d_name[];
+  /*
+  char pad
+  char d_type;
+  */
+};
+
+class DirentBuilder {
+public:
+  void append(const std::string& name) {
+    m_names.push_back (name);
+  }
+
+  std::vector<char> data() const {
+    std::vector<char> ret;
+    for (auto i = m_names.cbegin(); i != m_names.cend(); i++) {
+      push (ret, *i);
+    }
+    return ret;
+  }
+
+private:
+  std::vector<std::string> m_names;
+
+  void push(std::vector<char>& ret, const std::string& name) const {
+    static long inode = 4242;
+    unsigned short reclen;
+    char* d_type;
+
+    reclen = sizeof (linux_dirent) + name.size() + sizeof (char) * 3;
+    off_t start = ret.size();
+    ret.resize (start + reclen);
+    linux_dirent* ent = reinterpret_cast<linux_dirent*>(&ret.data()[start]);
+    ent->d_ino = inode++;
+    ent->d_reclen = reclen;
+    memcpy (ent->d_name, name.data(), name.size() + 1);
+    d_type = reinterpret_cast<char*>(ent + reclen - 1);
+    *d_type = DT_REG;
+  }
+};
+
+VFS::VFS(Sandbox* sandbox)
+  : m_sbox (sandbox)
+{
+}
+
+std::string
+VFS::getFilename(Sandbox::Address addr) const
+{
+  std::vector<char> buf (1024);
+  m_sbox->copyString (addr, buf.size(), buf.data());
+  return std::string (buf.data());
+}
+
+
+int
+VFS::fromVirtualFD(int fd)
+{
+  if (fd >= 4095)
+    return fd - 4095;
+  return -1;
+}
+
+int
+VFS::toVirtualFD(int fd)
+{
+  return fd + 4095;
+}
+
+Sandbox::SyscallCall
+VFS::handleSyscall(const Sandbox::SyscallCall& call)
+{
+  Sandbox::SyscallCall ret(call);
+  if (call.id == SYS_open) {
+    std::string fname = getFilename(call.args[0]);
+    std::cout << "attempt " << fname << std::endl;
+    if (strncmp (fname.c_str(), "/usr/lib", strlen("/usr/lib")) != 0 && strncmp (fname.c_str(), "/lib", strlen("/lib") != 0)) {
+      ret.id = -1;
+      int fh = open (fname.c_str(), call.args[1]);
+      if (fh > -1) {
+        ret.returnVal = toVirtualFD(fh);
+      } else {
+        ret.returnVal = fh;
+      }
+      std::cout << "open " << fname << " = " << fh << std::endl;
+    }
+  } else if (call.id == __NR_close) {
+    int fd = fromVirtualFD(call.args[0]);
+    if (fd > -1) {
+      ret.id = -1;
+      ret.returnVal = close (fd);
+      std::cout << "close " << fd << std::endl;
+    }
+  } else if (call.id == __NR_read) {
+    int fd = fromVirtualFD(call.args[0]);
+    if (fd > -1) {
+      ret.id = -1;
+      std::vector<char> buf (call.args[2]);
+      ssize_t readCount = read (fd, buf.data(), buf.size());
+      m_sbox->writeData (call.args[1], buf.size(), buf.data());
+      ret.returnVal = readCount;
+      std::cout << "read " << fd << " = " << readCount << std::endl;
+      std::cout << std::hex;
+      for (unsigned int i = 0;i < buf.size(); i++) {
+        std::cout << (Sandbox::Word) buf[i] << " ";
+      }
+      std::cout << std::endl;
+    }
+  } else if (call.id == __NR_fstat) {
+    int fd = fromVirtualFD(call.args[0]);
+    if (fd > -1) {
+      ret.id = -1;
+      struct stat sbuf;
+      ret.returnVal = fstat (fd, &sbuf);
+      m_sbox->writeData(call.args[1], sizeof (sbuf), (char*)&sbuf);
+    }
+  } else if (call.id == __NR_getdents) {
+    static bool read = false;
+    ret.id = -1;
+    std::cout << "call getdents" << std::endl;
+    if (!read) {
+      std::vector<char> buf;
+      DirentBuilder builder;
+      builder.append ("hello");
+      builder.append ("codius");
+      buf = builder.data();
+      m_sbox->writeData(call.args[1], buf.size(), buf.data());
+      ret.returnVal = buf.size();
+      read = true;
+    } else {
+      ret.returnVal = 0;
+    }
+  }
+  return ret;
+}

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -57,13 +57,19 @@ private:
 
 VFS::VFS(Sandbox* sandbox)
   : m_sbox (sandbox)
-  , m_fs (new NativeFilesystem("/tmp/sbox-root/"))
 {
   m_whitelist.push_back ("/lib64/tls/x86_64/libc.so.6");
   m_whitelist.push_back ("/lib64/tls/libc.so.6");
   m_whitelist.push_back ("/lib64/x86_64/libc.so.6");
   m_whitelist.push_back ("/lib64/libc.so.6");
   m_whitelist.push_back ("/etc/ld.so.cache");
+  mountFilesystem (std::string("/codius"), std::shared_ptr<Filesystem>(new NativeFilesystem ("/tmp/sbox-root")));
+}
+
+void
+VFS::mountFilesystem(const std::string& path, std::shared_ptr<Filesystem> fs)
+{
+  m_mountpoints.insert (std::make_pair (path, fs));
 }
 
 std::string
@@ -89,6 +95,25 @@ VFS::toVirtualFD(int fd)
   return fd + 4095;
 }
 
+std::shared_ptr<Filesystem>
+VFS::getFilesystem(int fd) const
+{
+  return m_openFiles.at(fd);
+}
+
+std::pair<std::string, std::shared_ptr<Filesystem> >
+VFS::getFilesystem(const std::string& path) const
+{
+  std::string longest_mount;
+  for(auto i = m_mountpoints.cbegin(); i != m_mountpoints.cend(); i++) {
+    if (path.compare(0, i->first.size(), i->first) == 0) {
+      std::string newPath (path.substr (i->first.size()));
+      return std::make_pair (newPath, i->second);
+    }
+  }
+  return std::make_pair (std::string(), nullptr);
+}
+
 void
 VFS::do_openat (Sandbox::SyscallCall& call)
 {
@@ -105,12 +130,26 @@ VFS::do_openat (Sandbox::SyscallCall& call)
 
     if (!isWhitelisted (fname)) {
       call.id = -1;
-      call.returnVal = toVirtualFD (m_fs->open (absPath.c_str(), call.args[2]));
+      std::pair<std::string, std::shared_ptr<Filesystem> > fs = getFilesystem (fname);
+      if (fs.second) {
+        int fd = fs.second->open (fs.first.c_str(), call.args[2]);
+        m_openFiles.insert (std::make_pair (fd, fs.second));
+        call.returnVal = toVirtualFD (fd);
+      } else {
+        call.returnVal = -ENOENT;
+      }
     }
   } else {
     //FIXME: fd should be verified to make sure one can't do dup2(AT_FDCWD, foo)
+    //FIXME: Should also use map of opened filenames to figure out what
+    //filesystem we end up on
     call.id = -1;
-    call.returnVal = m_fs->openat (fd, fname.c_str(), call.args[2], call.args[3]);
+    std::pair<std::string, std::shared_ptr<Filesystem> > fs = getFilesystem (fname);
+    if (fs.second) {
+      call.returnVal = fs.second->openat (fd, fs.first.c_str(), call.args[2], call.args[3]);
+    } else {
+      call.returnVal = -ENOENT;
+    }
   }
 }
 
@@ -120,7 +159,14 @@ VFS::do_open (Sandbox::SyscallCall& call)
   std::string fname = getFilename (call.args[0]);
   if (!isWhitelisted (fname)) {
     call.id = -1;
-    call.returnVal = toVirtualFD (m_fs->open (fname.c_str(), call.args[1]));
+    std::pair<std::string, std::shared_ptr<Filesystem> > fs = getFilesystem (fname);
+    if (fs.second) {
+      int fd = fs.second->open (fs.first.c_str(), call.args[0]);
+      m_openFiles.insert (std::make_pair (fd, fs.second));
+      call.returnVal = toVirtualFD (fd);
+    } else {
+      call.returnVal = -ENOENT;
+    }
   }
 }
 
@@ -130,7 +176,12 @@ VFS::do_close (Sandbox::SyscallCall& call)
   int fh = fromVirtualFD (call.args[0]);
   if (fh > 0) {
     call.id = -1;
-    call.returnVal = m_fs->close (fh);
+    std::shared_ptr<Filesystem> fs = getFilesystem (fh);
+    if (fs) {
+      call.returnVal = fs->close (fh);
+    } else {
+      call.returnVal = -EBADF;
+    }
   }
 }
 
@@ -141,9 +192,14 @@ VFS::do_read (Sandbox::SyscallCall& call)
   if (fh > 0) {
     call.id = -1;
     std::vector<char> buf (call.args[2]);
-    ssize_t readCount = m_fs->read (fh, buf.data(), buf.size());
-    m_sbox->writeData (call.args[1], buf.size(), buf.data());
-    call.returnVal = readCount;
+    std::shared_ptr<Filesystem> fs = getFilesystem (fh);
+    if (fs) {
+      ssize_t readCount = fs->read (fh, buf.data(), buf.size());
+      m_sbox->writeData (call.args[1], buf.size(), buf.data());
+      call.returnVal = readCount;
+    } else {
+      call.returnVal = -EBADF;
+    }
   }
 }
 
@@ -152,10 +208,15 @@ VFS::do_fstat (Sandbox::SyscallCall& call)
 {
   int fd = fromVirtualFD (call.args[0]);
   if (fd > -1) {
-    call.id = -1;
     struct stat sbuf;
-    call.returnVal = m_fs->fstat (fd, &sbuf);
-    m_sbox->writeData(call.args[1], sizeof (sbuf), (char*)&sbuf);
+    call.id = -1;
+    std::shared_ptr<Filesystem> fs = getFilesystem (fd);
+    if (fs) {
+      call.returnVal = fs->fstat (fd, &sbuf);
+      m_sbox->writeData(call.args[1], sizeof (sbuf), (char*)&sbuf);
+    } else {
+      call.returnVal = -EBADF;
+    }
   }
 }
 
@@ -164,11 +225,16 @@ VFS::do_getdents (Sandbox::SyscallCall& call)
 {
   int fd = fromVirtualFD (call.args[0]);
   if (fd > -1) {
-    void* buf = malloc (call.args[2]);
     call.id = -1;
-    call.returnVal = m_fs->getdents (fd, (struct linux_dirent*)buf, call.args[2]);
-    m_sbox->writeData(call.args[1], call.args[2], (char*)buf);
-    free (buf);
+    std::shared_ptr<Filesystem> fs = getFilesystem (fd);
+    if (fs) {
+      void* buf = malloc (call.args[2]);
+      call.returnVal = fs->getdents (fd, (struct linux_dirent*)buf, call.args[2]);
+      m_sbox->writeData(call.args[1], call.args[2], (char*)buf);
+      free (buf);
+    } else {
+      call.returnVal = -EBADF;
+    }
   }
 }
 

--- a/test/sandbox.cpp
+++ b/test/sandbox.cpp
@@ -126,7 +126,7 @@ public:
 
     void testSimpleProgram()
     {
-      _run (SYS_read);
+      _run (SYS_exit);
       sbox->waitExit();
       CPPUNIT_ASSERT_EQUAL (0, sbox->exitStatus);
     }
@@ -135,7 +135,7 @@ public:
     {
       _run (SYS_open);
       sbox->waitExit();
-      CPPUNIT_ASSERT_EQUAL (14, sbox->exitStatus);
+      CPPUNIT_ASSERT_EQUAL (2, sbox->exitStatus);
     }
 
     void testInterceptSyscall()


### PR DESCRIPTION
This is a large bundle of commits that implements a virtual filesystem inside sandboxed processes.

One starts by mounting a filesystem by way of passing a mountpoint and Filesystem implementation to Sandbox::getVFS().mountFilesystem(). The VFS layer automatically handles mapping filesystem-specific file descriptor numbers to virtual descriptor numbers within the sandbox and back along with passing filesystem-relative paths to implementations with open/openat/access/etc.

Non-virtualized file descriptors (such as ones handled via IPC channels) are left untouched and syscall operations on those FDs are transparently handled by the kernel instead of the sandbox. A future revision of this API will allow Filesystems to simply rewrite syscalls to produce native file descriptors, eliminating a lot of the super slow userland ptrace() calls to read/write buffers.
