### PR TITLE
Fix compiler error if AT_FDCWD is signed

### DIFF
--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -137,7 +137,7 @@ VFS::do_openat (Sandbox::SyscallCall& call)
 
   if (fname[0] != '/') {
     std::string fdPath;
-    if (call.args[0] == AT_FDCWD) {
+    if (call.args[0] == static_cast<unsigned long>(AT_FDCWD)) {
       fdPath = m_cwd->path();
     } else if (isVirtualFD (call.args[0])) {
       File::Ptr file = getFile (call.args[0]);


### PR DESCRIPTION
Fixes the following compiler error:

```
$ npm install       

> codius-sandbox@0.0.1 install /var/www/codius-engine/node_modules/codius-sandbox
> node-gyp rebuild

make: Entering directory '/var/www/codius-engine/node_modules/codius-sandbox/build'
  CC(target) Release/obj.target/codius-sandbox-rpc/src/json.o
  CC(target) Release/obj.target/codius-sandbox-rpc/src/codius-util.o
  AR(target) Release/obj.target/codius-sandbox-rpc.a
  COPY Release/codius-sandbox-rpc.a
  CXX(target) Release/obj.target/codius-sandbox/src/sandbox.o
  CXX(target) Release/obj.target/codius-sandbox/src/sandbox-ipc.o
  CXX(target) Release/obj.target/codius-sandbox/src/vfs.o
../src/vfs.cpp: In member function ‘void VFS::do_openat(Sandbox::SyscallCall&)’:
../src/vfs.cpp:140:22: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
     if (call.args[0] == AT_FDCWD) {
                      ^
cc1plus: all warnings being treated as errors
codius-sandbox.target.mk:89: recipe for target 'Release/obj.target/codius-sandbox/src/vfs.o' failed
make: *** [Release/obj.target/codius-sandbox/src/vfs.o] Error 1
make: Leaving directory '/var/www/codius-engine/node_modules/codius-sandbox/build'
```
